### PR TITLE
ci: レビュアーにチームを指定するように変更

### DIFF
--- a/.github/workflows/auto-assign.yaml
+++ b/.github/workflows/auto-assign.yaml
@@ -48,7 +48,7 @@ jobs:
             -H "Authorization: Bearer ${{ steps.app-token.outputs.token }}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/requested_reviewers \
-            -d '{"reviewers": $reviewers, "team_reviewers": $team_reviewers}'
+            -d '{"reviewers": "$reviewers", "team_reviewers": "$team_reviewers"}'
   request-assignees:
     needs:
       - count-reviewers

--- a/.github/workflows/auto-assign.yaml
+++ b/.github/workflows/auto-assign.yaml
@@ -21,13 +21,18 @@ jobs:
       # https://docs.github.com/ja/rest/pulls/review-requests?apiVersion=2022-11-28#request-reviewers-for-a-pull-request
       - name: Set reviewers
         run: |
-          curl -L \
-            -X POST \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${{ steps.app-token.outputs.token }}" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/requested_reviewers \
-            -d '{"team_reviewers":["flutter_mobile_project_template"]}'
+          # https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=opened#pull_request
+          # https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=ready_for_review#pull_request
+          reviewers_count=$(cat ${{ github.event_path }} | jq '.pull_request.requested_reviewers | length')
+          if [[ $reviewers_count == 0 ]]; then
+            curl -L \
+              -X POST \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${{ steps.app-token.outputs.token }}" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/requested_reviewers \
+              -d '{"team_reviewers":["flutter_mobile_project_template"]}'
+          fi
       - name: Set assignees
         uses: hkusu/review-assign-action@v1
         with:

--- a/.github/workflows/auto-assign.yaml
+++ b/.github/workflows/auto-assign.yaml
@@ -8,7 +8,23 @@ permissions:
   pull-requests: write
 
 jobs:
-  assign:
+  count-reviewers:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    outputs:
+      count: ${{ steps.extract.outputs.count }}
+    steps:
+      - name: Extract the number of reviewers
+        id: extract
+        run: |
+          # https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=opened#pull_request
+          # https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=ready_for_review#pull_request
+          reviewers_count=$(cat ${{ github.event_path }} | jq '.pull_request.requested_reviewers | length')
+          echo "count=$reviewers_count" >> "$GITHUB_OUTPUT"
+  request-reviewers:
+    needs:
+      - count-reviewers
+    if: needs.count-reviewers.outputs.count == '0'
     runs-on: ubuntu-22.04
     timeout-minutes: 5
     steps:
@@ -18,22 +34,30 @@ jobs:
         with:
           app-id: ${{ secrets.APP_ID_OF_YUMEMI_TEAM_REVIEW_REQUESTER }}
           private-key: ${{ secrets.APP_PRIVATE_KEY_OF_YUMEMI_TEAM_REVIEW_REQUESTER }}
-      # https://docs.github.com/ja/rest/pulls/review-requests?apiVersion=2022-11-28#request-reviewers-for-a-pull-request
-      - name: Set reviewers
+      - name: Request reviewers
+        env:
+          REVIEWERS: ${{ vars.REVIEWERS }}
+          TEAM_REVIEWERS: ${{ vars.TEAM_REVIEWERS }}
         run: |
-          # https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=opened#pull_request
-          # https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=ready_for_review#pull_request
-          reviewers_count=$(cat ${{ github.event_path }} | jq '.pull_request.requested_reviewers | length')
-          if [[ $reviewers_count == 0 ]]; then
-            curl -L \
-              -X POST \
-              -H "Accept: application/vnd.github+json" \
-              -H "Authorization: Bearer ${{ steps.app-token.outputs.token }}" \
-              -H "X-GitHub-Api-Version: 2022-11-28" \
-              https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/requested_reviewers \
-              -d '{"team_reviewers":["flutter_mobile_project_template"]}'
-          fi
-      - name: Set assignees
+          reviewers=$(echo "\"${REVIEWERS// /}\"" | jq 'split(",")')
+          team_reviewers=$(echo "\"${TEAM_REVIEWERS// /}\"" | jq 'split(",")')
+          # https://docs.github.com/ja/rest/pulls/review-requests?apiVersion=2022-11-28#request-reviewers-for-a-pull-request
+          curl -L \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ steps.app-token.outputs.token }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/requested_reviewers \
+            -d '{"reviewers": $reviewers, "team_reviewers": $team_reviewers}'
+  request-assignees:
+    needs:
+      - count-reviewers
+      - request-reviewers
+    if: always()
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    steps:
+      - name: Request assignees
         uses: hkusu/review-assign-action@v1
         with:
           assignees: ${{ github.actor }}

--- a/.github/workflows/auto-assign.yaml
+++ b/.github/workflows/auto-assign.yaml
@@ -12,9 +12,24 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 5
     steps:
-      - uses: hkusu/review-assign-action@v1
+      - name: Generate a token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID_OF_YUMEMI_TEAM_REVIEW_REQUESTER }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY_OF_YUMEMI_TEAM_REVIEW_REQUESTER }}
+      # https://docs.github.com/ja/rest/pulls/review-requests?apiVersion=2022-11-28#request-reviewers-for-a-pull-request
+      - name: Set reviewers
+        run: |
+          curl -L \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ steps.app-token.outputs.token }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/requested_reviewers \
+            -d '{"team_reviewers":["flutter_mobile_project_template"]}'
+      - name: Set assignees
+        uses: hkusu/review-assign-action@v1
         with:
           assignees: ${{ github.actor }}
-          reviewers: ${{ vars.REVIEWERS }}
-          max-num-of-reviewers: 2
           ready-comment: 'Ready for review :rocket:'

--- a/.github/workflows/auto-assign.yaml
+++ b/.github/workflows/auto-assign.yaml
@@ -48,7 +48,7 @@ jobs:
             -H "Authorization: Bearer ${{ steps.app-token.outputs.token }}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/requested_reviewers \
-            -d '{"reviewers": "$reviewers", "team_reviewers": "$team_reviewers"}'
+            -d "{ \"reviewers\": $reviewers, \"team_reviewers\": $team_reviewers }"
   request-assignees:
     needs:
       - count-reviewers


### PR DESCRIPTION
## 概要

- close: #128 

## レビュー観点

- チームがレビュアーに自動で設定されるか
- アサインには、変わらずプルリクエスト作成者が設定されるか

## レビューレベル

- [x] Lv1: ぱっとみて違和感がないかチェックして Approve する
- [ ] Lv2: 仕様レベルまで理解して、仕様通りに動くかある程度検証して Approve する
- [ ] Lv3: 実際に環境で動作確認したうえで Approve する

## レビュー優先度

- [ ] すぐに見てもらいたい ( hotfix など ) 🚀
- [ ] 今日中に見てもらいたい 🚗
- [x] 今日〜明日中で見てもらいたい 🚶
- [ ] 数日以内で見てもらいたい 🐢

## 画像 / 動画

※ 見た目の変更がないため省略

## 動作確認手順

GitHub Actions のワークフローの実行結果を確認する。

※ ↓無事に動作しているようです！


## 備考

- マージ後にリポジトリの変数として定義していた `REVIEWERS` は削除予定