### PR TITLE
ci: check-pr ワークフローがタイムアウトで失敗しないように一時的な対応

### DIFF
--- a/.github/workflows/check-pr.yaml
+++ b/.github/workflows/check-pr.yaml
@@ -34,7 +34,7 @@ jobs:
     needs: pre-check
     if: ${{ needs.pre-check.outputs.src == 'true' }}
     runs-on: ubuntu-22.04
-    timeout-minutes: 10
+    timeout-minutes: 20
 
     steps:
       # https://github.com/actions/checkout

--- a/.github/workflows/check-pr.yaml
+++ b/.github/workflows/check-pr.yaml
@@ -10,6 +10,8 @@ jobs:
     outputs:
       src: ${{ steps.filter.outputs.src }}
     runs-on: ubuntu-22.04
+    timeout-minutes: 5
+
     steps:
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
         id: filter


### PR DESCRIPTION
## 概要

#191

根本的な対応は、時間のかかっているステップの時間をどうにか短くしないといけないため、クローズはしません。

ついでに pre-check ジョブのタイムアウト時間を念の為設定しておきました。

## レビュー観点

- 設定値は妥当か
- 設定のミスはないか

## レビューレベル

- [x] Lv1: ぱっとみて違和感がないかチェックして Approve する
- [ ] Lv2: 仕様レベルまで理解して、仕様通りに動くかある程度検証して Approve する
- [ ] Lv3: 実際に環境で動作確認したうえで Approve する

## レビュー優先度

- [ ] すぐに見てもらいたい ( hotfix など ) 🚀
- [ ] 今日中に見てもらいたい 🚗
- [ ] 今日〜明日中で見てもらいたい 🚶
- [x] 数日以内で見てもらいたい 🐢

## 画像 / 動画

見た目に関する変更がないため省略します。

## 動作確認手順

見た目に関する変更がないため省略します。

## 備考

特になし