### PR TITLE
Refactor appStatus provider to use existing state instances directly

### DIFF
--- a/packages/cores/core/lib/src/app_status/provider/app_status_provider.dart
+++ b/packages/cores/core/lib/src/app_status/provider/app_status_provider.dart
@@ -1,6 +1,4 @@
 import 'package:cores_core/src/app_status/model/app_status.dart';
-import 'package:cores_core/src/app_status/model/force_update_status.dart';
-import 'package:cores_core/src/app_status/model/maintenance_mode_status.dart';
 import 'package:cores_core/src/app_status/provider/force_update_provider.dart';
 import 'package:cores_core/src/app_status/provider/maintenance_mode_provider.dart';
 
@@ -10,15 +8,11 @@ part 'app_status_provider.g.dart';
 
 @Riverpod(keepAlive: true)
 AppStatus appStatus(AppStatusRef ref) {
-  final maintenanceModeState = ref.watch(maintenanceModeProvider);
-  final forceUpdateState = ref.watch(forceUpdateProvider);
+  final maintenanceModeStatus = ref.watch(maintenanceModeProvider);
+  final forceUpdateStatus = ref.watch(forceUpdateProvider);
 
   return AppStatus(
-    maintenanceModeStatus: MaintenanceModeStatus(
-      enabled: maintenanceModeState.enabled,
-    ),
-    forceUpdateStatus: ForceUpdateStatus(
-      enabled: forceUpdateState.enabled,
-    ),
+    maintenanceModeStatus: maintenanceModeStatus,
+    forceUpdateStatus: forceUpdateStatus,
   );
 }


### PR DESCRIPTION
## 概要

`appStatus` provider において、 `MaintenanceModeStatus` と `ForceUpdateStatus` の不要なインスタンス再生成があったので修正しました。

### 問題点

インスタンス生成のオーバーヘッドやメモリ使用量の増大はわずかだと思いますが、都度生成していると今後 `MaintenanceModeStatus` や `ForceUpdateStatus` に、メンバーの追加があるがコンストラクタでデフォルト値が設定されているという場合に古い値が無視されてしまうことが懸念されます。

## レビュー観点

- インスタンスを再生成していた特別な理由が無いか

## レビューレベル

- [ ] Lv1: ぱっとみて違和感がないかチェックして Approve する
- [x] Lv2: 仕様レベルまで理解して、仕様通りに動くかある程度検証して Approve する
- [ ] Lv3: 実際に環境で動作確認したうえで Approve する

## レビュー優先度

- [ ] すぐに見てもらいたい ( hotfix など ) 🚀
- [ ] 今日中に見てもらいたい 🚗
- [ ] 今日〜明日中で見てもらいたい 🚶
- [x] 数日以内で見てもらいたい 🐢

## 画像 / 動画

この変更後にメンテナンスモードと強制アップデートの状態変更が監視できているのは確認しました。

<video width=300 src="https://github.com/yumemi-inc/flutter-mobile-project-template/assets/31601805/c7233a9b-c204-4a49-bb05-5885992376ad">

## 備考

<!--
参考文献などがあれば記載してください。
また、マージするタイミングが特殊という注意事項などあればあわせて記載してください。
-->
