### PR TITLE
pubspec.yaml においてローカルパッケージへの参照部分で戻り過ぎていた階層を修正

### DIFF
--- a/packages/features/setting/pubspec.yaml
+++ b/packages/features/setting/pubspec.yaml
@@ -9,11 +9,11 @@ environment:
 
 dependencies:
   cores_core:
-    path: ../../../packages/cores/core
+    path: ../../cores/core
   cores_data:
-    path: ../../../packages/cores/data
+    path: ../../cores/data
   cores_navigation:
-    path: ../../../packages/cores/navigation
+    path: ../../cores/navigation
   flutter:
     sdk: flutter
   flutter_localizations:


### PR DESCRIPTION
## 概要

たまたま見つけた軽微な修正のため、Issue の作成はスキップしてそのまま PR 作成しました。

```diff
-    path: ../../../packages/cores/core
+    path: ../../cores/core
```

上記のような参照 path を修正しています。
動作には変更がないリファクタリングになります。

## レビュー観点

- CI 🟢 

## レビューレベル

- [x] Lv1: ぱっとみて違和感がないかチェックして Approve する
- [ ] Lv2: 仕様レベルまで理解して、仕様通りに動くかある程度検証して Approve する
- [ ] Lv3: 実際に環境で動作確認したうえで Approve する

## レビュー優先度

- [ ] すぐに見てもらいたい ( hotfix など ) 🚀
- [ ] 今日中に見てもらいたい 🚗
- [ ] 今日〜明日中で見てもらいたい 🚶
- [x] 数日以内で見てもらいたい 🐢

## 画像 / 動画

省略

## 動作確認手順

CI 🟢 

## 備考

<!--
参考文献などがあれば記載してください。
また、マージするタイミングが特殊という注意事項などあればあわせて記載してください。
-->
