### PR TITLE
デバッグ時に、任意の画面にすぐ遷移できるようにする

### DIFF
--- a/apps/app/lib/router/provider/router.g.dart
+++ b/apps/app/lib/router/provider/router.g.dart
@@ -30,6 +30,14 @@ RouteBase get $mainPageShellRoute => StatefulShellRouteData.$route(
                   path: 'debug',
                   parentNavigatorKey: DebugPageRoute.$parentNavigatorKey,
                   factory: $DebugPageRouteExtension._fromState,
+                  routes: [
+                    GoRouteData.$route(
+                      path: 'navigation_debug',
+                      parentNavigatorKey:
+                          NavigationDebugPageRoute.$parentNavigatorKey,
+                      factory: $NavigationDebugPageRouteExtension._fromState,
+                    ),
+                  ],
                 ),
                 GoRouteData.$route(
                   path: 'web',
@@ -111,6 +119,24 @@ extension $DebugPageRouteExtension on DebugPageRoute {
 
   String get location => GoRouteData.$location(
         '/debug',
+      );
+
+  void go(BuildContext context) => context.go(location);
+
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  void replace(BuildContext context) => context.replace(location);
+}
+
+extension $NavigationDebugPageRouteExtension on NavigationDebugPageRoute {
+  static NavigationDebugPageRoute _fromState(GoRouterState state) =>
+      const NavigationDebugPageRoute();
+
+  String get location => GoRouteData.$location(
+        '/debug/navigation_debug',
       );
 
   void go(BuildContext context) => context.go(location);

--- a/apps/app/lib/router/routes/main/home/debug_page_route.dart
+++ b/apps/app/lib/router/routes/main/home/debug_page_route.dart
@@ -1,5 +1,14 @@
 part of 'package:flutter_app/router/provider/router.dart';
 
+final class _DebugPageNavigatorImpl implements DebugPageNavigator {
+  const _DebugPageNavigatorImpl();
+
+  @override
+  void goNavigationDebugPage(BuildContext context) {
+    const NavigationDebugPageRoute().go(context);
+  }
+}
+
 class DebugPageRoute extends GoRouteData {
   const DebugPageRoute();
 
@@ -9,6 +18,26 @@ class DebugPageRoute extends GoRouteData {
 
   @override
   Widget build(BuildContext context, GoRouterState state) {
-    return const DebugPage();
+    return ProviderScope(
+      overrides: [
+        debugPageNavigatorProvider.overrideWithValue(
+          const _DebugPageNavigatorImpl(),
+        ),
+      ],
+      child: const DebugPage(),
+    );
+  }
+}
+
+class NavigationDebugPageRoute extends GoRouteData {
+  const NavigationDebugPageRoute();
+
+  static const path = 'navigation_debug';
+
+  static final $parentNavigatorKey = _rootNavigatorKey;
+
+  @override
+  Widget build(BuildContext context, GoRouterState state) {
+    return const NavigationDebugPage();
   }
 }

--- a/apps/app/lib/router/routes/main/home/home_shell_branch.dart
+++ b/apps/app/lib/router/routes/main/home/home_shell_branch.dart
@@ -10,6 +10,11 @@ const homeShellBranch = TypedStatefulShellBranch<HomeShellBranch>(
         ),
         TypedGoRoute<DebugPageRoute>(
           path: DebugPageRoute.path,
+          routes: [
+            TypedGoRoute<NavigationDebugPageRoute>(
+              path: NavigationDebugPageRoute.path,
+            ),
+          ],
         ),
         TypedGoRoute<WebPageRoute>(
           path: WebPageRoute.path,

--- a/melos.yaml
+++ b/melos.yaml
@@ -19,6 +19,7 @@ command:
       intl: ^0.19.0
       json_annotation: ^4.8.1
       riverpod_annotation: ^2.3.5
+      go_router: ^13.0.1
     dev_dependencies:
       build_runner: ^2.4.7
       custom_lint: ^0.6.4

--- a/packages/features/debug_mode/lib/src/ui/debug_page.dart
+++ b/packages/features/debug_mode/lib/src/ui/debug_page.dart
@@ -2,10 +2,11 @@ import 'dart:async';
 
 import 'package:cores_core/app_status.dart';
 import 'package:features_debug_mode/src/data/api/provider/exception_generator_api.dart';
+import 'package:features_debug_mode/src/ui/provider/navigator_provider.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-abstract interface class DebugNavigator {
+abstract interface class DebugPageNavigator {
   void goNavigationDebugPage(BuildContext context);
 }
 
@@ -45,6 +46,12 @@ class DebugPage extends ConsumerWidget {
                       androidTargetVersion: '9.9.9',
                     );
               },
+            ),
+            _FixSizedElevatedButton(
+              title: 'Go navigation debug page',
+              onPressed: () => ref
+                  .read(debugPageNavigatorProvider)
+                  .goNavigationDebugPage(context),
             ),
           ],
         ),

--- a/packages/features/debug_mode/lib/src/ui/debug_page.dart
+++ b/packages/features/debug_mode/lib/src/ui/debug_page.dart
@@ -5,6 +5,10 @@ import 'package:features_debug_mode/src/data/api/provider/exception_generator_ap
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+abstract interface class DebugNavigator {
+  void goNavigationDebugPage(BuildContext context);
+}
+
 class DebugPage extends ConsumerWidget {
   const DebugPage({super.key});
 

--- a/packages/features/debug_mode/lib/src/ui/navigation_debug_page.dart
+++ b/packages/features/debug_mode/lib/src/ui/navigation_debug_page.dart
@@ -26,50 +26,6 @@ class NavigationDebugPage extends ConsumerWidget {
   }
 }
 
-class StatefulShellRouteView extends StatelessWidget {
-  const StatefulShellRouteView({
-    required StatefulShellRoute route,
-    super.key,
-  }) : _route = route;
-
-  final StatefulShellRoute _route;
-
-  @override
-  Widget build(BuildContext context) {
-    return Column(
-      children: _route.routes
-          .map(
-            (route) => switch (route) {
-              GoRoute() => GoRouteView(route: route),
-              StatefulShellRoute() => StatefulShellRouteView(route: route),
-              _ => const SizedBox.shrink(),
-            },
-          )
-          .toList(),
-    );
-  }
-}
-
-class GoRouteView extends StatelessWidget {
-  const GoRouteView({
-    required GoRoute route,
-    super.key,
-  }) : _route = route;
-
-  final GoRoute _route;
-
-  @override
-  Widget build(BuildContext context) {
-    return ListTile(
-      title: Text(_route.path),
-      onTap: () {
-        final router = GoRouter.of(context);
-        router.go(_route.path);
-      },
-    );
-  }
-}
-
 final class RouteDropdownMenu extends HookWidget {
   const RouteDropdownMenu({super.key});
 

--- a/packages/features/debug_mode/lib/src/ui/navigation_debug_page.dart
+++ b/packages/features/debug_mode/lib/src/ui/navigation_debug_page.dart
@@ -1,14 +1,164 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 
-class NavigationDebugPage extends StatelessWidget {
+class NavigationDebugPage extends ConsumerWidget {
   const NavigationDebugPage({super.key});
 
   @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('画面遷移一覧'),
+  Widget build(BuildContext context, WidgetRef ref) {
+    return const Scaffold(
+      body: CustomScrollView(
+        slivers: [
+          SliverAppBar.large(
+            title: Text('Debug Page'),
+          ),
+          SliverToBoxAdapter(
+            child: Padding(
+              padding: EdgeInsets.symmetric(horizontal: 16),
+              child: RouteDropdownMenu(),
+            ),
+          ),
+        ],
       ),
     );
+  }
+}
+
+class StatefulShellRouteView extends StatelessWidget {
+  const StatefulShellRouteView({
+    required StatefulShellRoute route,
+    super.key,
+  }) : _route = route;
+
+  final StatefulShellRoute _route;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: _route.routes
+          .map(
+            (route) => switch (route) {
+              GoRoute() => GoRouteView(route: route),
+              StatefulShellRoute() => StatefulShellRouteView(route: route),
+              _ => const SizedBox.shrink(),
+            },
+          )
+          .toList(),
+    );
+  }
+}
+
+class GoRouteView extends StatelessWidget {
+  const GoRouteView({
+    required GoRoute route,
+    super.key,
+  }) : _route = route;
+
+  final GoRoute _route;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      title: Text(_route.path),
+      onTap: () {
+        final router = GoRouter.of(context);
+        router.go(_route.path);
+      },
+    );
+  }
+}
+
+final class RouteDropdownMenu extends HookWidget {
+  const RouteDropdownMenu({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final router = GoRouter.of(context);
+    final routeBases = router.configuration.routes;
+    final dropdownMenuEntries = useMemoized(
+      () {
+        final routes = routeBases.toRoutes();
+        return routes
+            .map(
+              (route) {
+                final routePath = route.path;
+
+                // デバッグ関連のルートは除外する
+                if (routePath.contains('debug')) {
+                  return null;
+                }
+                return DropdownMenuEntry<_Route>(
+                  value: route,
+                  label: routePath,
+                );
+              },
+            )
+            .nonNulls
+            .toList();
+      },
+      routeBases,
+    );
+    // DropdownMenu を親の横幅に合わせる
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        return DropdownMenu<_Route>(
+          width: constraints.maxWidth,
+          dropdownMenuEntries: dropdownMenuEntries,
+          // hintText: l.routeDropDownHintText,
+          onSelected: (route) {
+            if (route == null) {
+              return;
+            }
+            router.go(route.path);
+          },
+        );
+      },
+    );
+  }
+}
+
+extension _ToRoutes on List<RouteBase> {
+  List<_Route> toRoutes([_Route? parentRoute]) {
+    final routes = <_Route>[];
+    for (final routeBase in this) {
+      switch (routeBase) {
+        case GoRoute():
+          final route = _Route(
+            goRoute: routeBase,
+            parentRoute: parentRoute,
+          );
+          routes.add(route);
+
+          final childRouteBases = routeBase.routes;
+          if (childRouteBases.isNotEmpty) {
+            routes.addAll(childRouteBases.toRoutes(route));
+          }
+        case ShellRoute() || StatefulShellRoute():
+          routes.addAll(routeBase.routes.toRoutes());
+      }
+    }
+    return routes;
+  }
+}
+
+final class _Route {
+  _Route({
+    required GoRoute goRoute,
+    _Route? parentRoute,
+  })  : _goRoute = goRoute,
+        _parentRoute = parentRoute;
+
+  final GoRoute _goRoute;
+  final _Route? _parentRoute;
+
+  late final String path = _path;
+
+  String get _path {
+    if (_parentRoute == null) {
+      return _goRoute.path;
+    }
+    return '${_parentRoute._path}/${_goRoute.path}';
   }
 }

--- a/packages/features/debug_mode/lib/src/ui/navigation_debug_page.dart
+++ b/packages/features/debug_mode/lib/src/ui/navigation_debug_page.dart
@@ -159,7 +159,7 @@ final class _Route {
     final parentPath = _parentRoute?._path;
     final childPath = _goRoute.path;
     if (parentPath == null) {
-      return _goRoute.path;
+      return childPath;
     }
 
     return '${parentPath == '/' ? '' : parentPath}/$childPath';

--- a/packages/features/debug_mode/lib/src/ui/navigation_debug_page.dart
+++ b/packages/features/debug_mode/lib/src/ui/navigation_debug_page.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/material.dart';
+
+class NavigationDebugPage extends StatelessWidget {
+  const NavigationDebugPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('画面遷移一覧'),
+      ),
+    );
+  }
+}

--- a/packages/features/debug_mode/lib/src/ui/navigation_debug_page.dart
+++ b/packages/features/debug_mode/lib/src/ui/navigation_debug_page.dart
@@ -156,9 +156,12 @@ final class _Route {
   late final String path = _path;
 
   String get _path {
-    if (_parentRoute == null) {
+    final parentPath = _parentRoute?._path;
+    final childPath = _goRoute.path;
+    if (parentPath == null) {
       return _goRoute.path;
     }
-    return '${_parentRoute._path}/${_goRoute.path}';
+
+    return '${parentPath == '/' ? '' : parentPath}/$childPath';
   }
 }

--- a/packages/features/debug_mode/lib/src/ui/provider/navigator_provider.dart
+++ b/packages/features/debug_mode/lib/src/ui/provider/navigator_provider.dart
@@ -4,5 +4,5 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 part 'navigator_provider.g.dart';
 
 @Riverpod(dependencies: [])
-DebugNavigator debugNavigator(DebugNavigatorRef ref) =>
+DebugPageNavigator debugPageNavigator(DebugPageNavigatorRef ref) =>
     throw UnimplementedError();

--- a/packages/features/debug_mode/lib/src/ui/provider/navigator_provider.dart
+++ b/packages/features/debug_mode/lib/src/ui/provider/navigator_provider.dart
@@ -1,0 +1,8 @@
+import 'package:features_debug_mode/ui.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'navigator_provider.g.dart';
+
+@Riverpod(dependencies: [])
+DebugNavigator debugNavigator(DebugNavigatorRef ref) =>
+    throw UnimplementedError();

--- a/packages/features/debug_mode/lib/src/ui/provider/navigator_provider.g.dart
+++ b/packages/features/debug_mode/lib/src/ui/provider/navigator_provider.g.dart
@@ -8,20 +8,22 @@ part of 'navigator_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$debugNavigatorHash() => r'48d61c0b3a561e0f94c87db576b5481cb4f5e310';
+String _$debugPageNavigatorHash() =>
+    r'1234f344ef1cf619e3bfb742d28f6befc251e299';
 
-/// See also [debugNavigator].
-@ProviderFor(debugNavigator)
-final debugNavigatorProvider = AutoDisposeProvider<DebugNavigator>.internal(
-  debugNavigator,
-  name: r'debugNavigatorProvider',
+/// See also [debugPageNavigator].
+@ProviderFor(debugPageNavigator)
+final debugPageNavigatorProvider =
+    AutoDisposeProvider<DebugPageNavigator>.internal(
+  debugPageNavigator,
+  name: r'debugPageNavigatorProvider',
   debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
       ? null
-      : _$debugNavigatorHash,
+      : _$debugPageNavigatorHash,
   dependencies: const <ProviderOrFamily>[],
   allTransitiveDependencies: const <ProviderOrFamily>{},
 );
 
-typedef DebugNavigatorRef = AutoDisposeProviderRef<DebugNavigator>;
+typedef DebugPageNavigatorRef = AutoDisposeProviderRef<DebugPageNavigator>;
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/packages/features/debug_mode/lib/src/ui/provider/navigator_provider.g.dart
+++ b/packages/features/debug_mode/lib/src/ui/provider/navigator_provider.g.dart
@@ -1,0 +1,27 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, duplicate_ignore
+
+part of 'navigator_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$debugNavigatorHash() => r'48d61c0b3a561e0f94c87db576b5481cb4f5e310';
+
+/// See also [debugNavigator].
+@ProviderFor(debugNavigator)
+final debugNavigatorProvider = AutoDisposeProvider<DebugNavigator>.internal(
+  debugNavigator,
+  name: r'debugNavigatorProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$debugNavigatorHash,
+  dependencies: const <ProviderOrFamily>[],
+  allTransitiveDependencies: const <ProviderOrFamily>{},
+);
+
+typedef DebugNavigatorRef = AutoDisposeProviderRef<DebugNavigator>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/packages/features/debug_mode/lib/ui.dart
+++ b/packages/features/debug_mode/lib/ui.dart
@@ -1,2 +1,4 @@
 export 'src/ui/debug_page.dart';
 export 'src/ui/maintenance_page.dart';
+export 'src/ui/navigation_debug_page.dart';
+export 'src/ui/provider/navigator_provider.dart';

--- a/packages/features/debug_mode/pubspec.lock
+++ b/packages/features/debug_mode/pubspec.lock
@@ -267,6 +267,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_hooks:
+    dependency: "direct main"
+    description:
+      name: flutter_hooks
+      sha256: cde36b12f7188c85286fba9b38cc5a902e7279f36dd676967106c041dc9dde70
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.20.5"
   flutter_riverpod:
     dependency: "direct main"
     description:
@@ -304,6 +312,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.2"
+  go_router:
+    dependency: "direct main"
+    description:
+      name: go_router
+      sha256: b465e99ce64ba75e61c8c0ce3d87b66d8ac07f0b35d0a7e0263fcfc10f99e836
+      url: "https://pub.dev"
+    source: hosted
+    version: "13.2.5"
   graphs:
     dependency: transitive
     description:

--- a/packages/features/debug_mode/pubspec.yaml
+++ b/packages/features/debug_mode/pubspec.yaml
@@ -17,7 +17,9 @@ dependencies:
   dio: ^5.4.0
   flutter:
     sdk: flutter
+  flutter_hooks: ^0.20.5
   flutter_riverpod: ^2.5.1
+  go_router: ^13.0.1
   riverpod_annotation: ^2.3.5
 
 dev_dependencies:


### PR DESCRIPTION
## 概要

<!--
チケットがある場合は、チケットのリンクを記載してください。
ただし、チケットがない場合は、背景・実装内容・仕様などを簡潔に記載してください。

例:
- close: #ISSUE_NUMBER
- xxx という課題があったため、xxx という機能を実装しました。仕様は xxx をご覧ください。
-->

close: #235

- こちらをベースに一部バグを修正しています
https://github.com/FlutterKaigi/2024/pull/120
- 元Issueの「デバッグ時のみ」をどう実現するのが良さそうかは別途考える必要がありそうなので、このPRではやってません。（遷移元のボタンを消す？）

## レビュー観点

<!--
レビュアに確認してほしい事柄を記載してください。
特に、本 PR にてレビュー対象外の内容があれば合わせて記載してください。

例:
- デザインだけ組み込んだので、仕様についてはレビュー対象外として欲しい
- このコミット xxxxxxx ( commit hash ) を主にレビューして欲しい
-->

## レビューレベル

- [x] Lv1: ぱっとみて違和感がないかチェックして Approve する
- [ ] Lv2: 仕様レベルまで理解して、仕様通りに動くかある程度検証して Approve する
- [ ] Lv3: 実際に環境で動作確認したうえで Approve する

## レビュー優先度

- [ ] すぐに見てもらいたい ( hotfix など ) 🚀
- [ ] 今日中に見てもらいたい 🚗
- [x] 今日〜明日中で見てもらいたい 🚶
- [ ] 数日以内で見てもらいたい 🐢

## 画像 / 動画

<!--
見た目に関する変更がある場合、内容を記載したり画像・動画を添付したりしてください。
特に、動作やアニメーションなどもレビューして欲しい場合は、動作確認手順を書いたり、の添付をお願い致します。

例:
- 見た目に関する変更がないため省略します。
- 決定ボタンをタップ時に、表示変化があります。動画添付します。
-->

|           デバッグ画面           |           ナビゲーションデバッグ画面            |
|:--------------------------:|:--------------------------:|
| <img src="https://github.com/yumemi-inc/flutter-mobile-project-template/assets/90010509/9c2cf03c-9b4e-4ea0-af89-88c4d20f6253" width="300" /> | <img src="https://github.com/yumemi-inc/flutter-mobile-project-template/assets/90010509/83d77a77-2774-4c1a-a6e4-fcfcd7c90579" width="300" /> |

## 確認したこと

<!--
PR作成にあたって確認した事柄を記載してください。

例:
- [x] ローディングが表示されること
- [ ] エラーが表示されること
-->

## 動作確認手順

<!--
動作確認する際の手順や必要な情報を記載してください。

例:
1. xxx という ID でログインする。（パスワードは https://xxx~ を参照 ）
2. xxx という画面を開いて、xxx というボタンをクリックする。
-->

- 画像のデバッグ画面から、ナビゲーションデバッグ画面へ遷移
- ドロップダウンで遷移したい画面を選択

## 備考

<!--
参考文献などがあれば記載してください。
また、マージするタイミングが特殊という注意事項などあればあわせて記載してください。
-->

このPRでやれてないことをIssue化
#267 
#268 