### PR TITLE
fix: website でも Flutter のバージョンを指定

### DIFF
--- a/apps/website/pubspec.lock
+++ b/apps/website/pubspec.lock
@@ -538,4 +538,4 @@ packages:
     version: "2.1.0"
 sdks:
   dart: ">=3.4.1 <4.0.0"
-  flutter: ">=3.19.0"
+  flutter: ">=3.22.1"

--- a/apps/website/pubspec.yaml
+++ b/apps/website/pubspec.yaml
@@ -5,7 +5,8 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: '>=3.4.1 <4.0.0'
+  sdk: ^3.4.1
+  flutter: ^3.22.1
 
 dependencies:
   flutter:


### PR DESCRIPTION
## 概要

チケットはありません。

website で Flutter のバージョンを指定していなかったため、 `melos bs` コマンドでエラーが発生してしまっていました。

```shell
--------------------------------------------------------------------------------------------------------------------------
[website]: Please put [flutter: Flutter Version] under the environment section in pubspec.yaml
--------------------------------------------------------------------------------------------------------------------------

$ melos exec
  └> dart run yumemi_lints update
     └> FAILED (in 1 packages)
        └> website (with exit code 1)

melos run yumemi_lints_update
  └> melos exec -- "dart run yumemi_lints update"
     └> FAILED
ERROR: ERROR: ScriptException: The script yumemi_lints_update failed to execute.
```

## レビュー観点

- `melos bs` コマンドを実行してエラーが発生しないか

## レビューレベル

- [ ] Lv1: ぱっとみて違和感がないかチェックして Approve する
- [x] Lv2: 仕様レベルまで理解して、仕様通りに動くかある程度検証して Approve する
- [ ] Lv3: 実際に環境で動作確認したうえで Approve する

## レビュー優先度

- [ ] すぐに見てもらいたい ( hotfix など ) 🚀
- [ ] 今日中に見てもらいたい 🚗
- [ ] 今日〜明日中で見てもらいたい 🚶
- [x] 数日以内で見てもらいたい 🐢

## 画像 / 動画

見た目に関する変更がないため省略します。

## 備考

特になし