### PR TITLE
[GH-441] infrastructureパッケージへの切り出し

### DIFF
--- a/packages/domain_logic/.gitignore
+++ b/packages/domain_logic/.gitignore
@@ -1,3 +1,29 @@
-# https://dart.dev/guides/libraries/private-files
-# Created by `dart pub`
+# Miscellaneous
+*.class
+*.log
+*.pyc
+*.swp
+.DS_Store
+.atom/
+.buildlog/
+.history
+.svn/
+migrate_working_dir/
+
+# IntelliJ related
+*.iml
+*.ipr
+*.iws
+.idea/
+
+# The .vscode folder contains launch configuration and tasks you configure in
+# VS Code which you may wish to be included in version control, so this line
+# is commented out by default.
+#.vscode/
+
+# Flutter/Dart/Pub related
+**/doc/api/
 .dart_tool/
+.flutter-plugins
+.flutter-plugins-dependencies
+build/

--- a/packages/domain_logic/lib/internal_domain_logic.dart
+++ b/packages/domain_logic/lib/internal_domain_logic.dart
@@ -4,5 +4,6 @@
 library;
 
 export 'src/internal_domain_logic_base.dart';
+export 'src/theme_mode/theme_mode_repository.dart';
 
 // TODO: Export any libraries intended for clients of this package.

--- a/packages/domain_logic/lib/src/theme_mode/theme_mode_repository.dart
+++ b/packages/domain_logic/lib/src/theme_mode/theme_mode_repository.dart
@@ -1,0 +1,6 @@
+import 'package:flutter/material.dart';
+
+abstract class ThemeModeRepository {
+  ThemeMode getThemeMode();
+  Future<void> saveThemeMode(ThemeMode themeMode);
+}

--- a/packages/domain_logic/pubspec.yaml
+++ b/packages/domain_logic/pubspec.yaml
@@ -9,6 +9,8 @@ environment:
 resolution: workspace
 
 dependencies:
+  flutter:
+    sdk: flutter
   internal_domain_model:
     path: ../domain_model
 

--- a/packages/infrastructure/.gitignore
+++ b/packages/infrastructure/.gitignore
@@ -1,3 +1,29 @@
-# https://dart.dev/guides/libraries/private-files
-# Created by `dart pub`
+# Miscellaneous
+*.class
+*.log
+*.pyc
+*.swp
+.DS_Store
+.atom/
+.buildlog/
+.history
+.svn/
+migrate_working_dir/
+
+# IntelliJ related
+*.iml
+*.ipr
+*.iws
+.idea/
+
+# The .vscode folder contains launch configuration and tasks you configure in
+# VS Code which you may wish to be included in version control, so this line
+# is commented out by default.
+#.vscode/
+
+# Flutter/Dart/Pub related
+**/doc/api/
 .dart_tool/
+.flutter-plugins
+.flutter-plugins-dependencies
+build/

--- a/packages/infrastructure/lib/internal_infrastructure.dart
+++ b/packages/infrastructure/lib/internal_infrastructure.dart
@@ -1,8 +1,14 @@
-/// Support for doing something awesome.
+/// Infrastructure layer package for data access
+/// and external service integration.
 ///
-/// More dartdocs go here.
+/// This package contains:
+/// - Repository implementations
+/// - API clients
+/// - Data storage services
 library;
 
 export 'src/internal_infrastructure_base.dart';
+export 'src/shared_preferences/shared_preference_data_source.dart';
+export 'src/shared_preferences/shared_preferences_keys.dart';
 
 // TODO: Export any libraries intended for clients of this package.

--- a/packages/infrastructure/lib/internal_infrastructure.dart
+++ b/packages/infrastructure/lib/internal_infrastructure.dart
@@ -10,5 +10,6 @@ library;
 export 'src/internal_infrastructure_base.dart';
 export 'src/shared_preferences/shared_preference_data_source.dart';
 export 'src/shared_preferences/shared_preferences_keys.dart';
+export 'src/theme_mode/theme_mode_repository_impl.dart';
 
 // TODO: Export any libraries intended for clients of this package.

--- a/packages/infrastructure/lib/src/shared_preferences/shared_preference_data_source.dart
+++ b/packages/infrastructure/lib/src/shared_preferences/shared_preference_data_source.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+import 'package:internal_infrastructure/internal_infrastructure.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class SharedPreferenceDataSource {
+  const SharedPreferenceDataSource(this._sharedPreferences);
+
+  final SharedPreferences _sharedPreferences;
+
+  ThemeMode getThemeMode() {
+    final themeIndex = _sharedPreferences.getInt(
+      SharedPreferencesKeys.themeMode.name,
+    );
+    return ThemeMode.values.singleWhere(
+      (themeMode) => themeMode.index == themeIndex,
+      orElse: () => ThemeMode.system,
+    );
+  }
+
+  Future<void> saveThemeMode(int themeIndex) async {
+    await _sharedPreferences.setInt(
+      SharedPreferencesKeys.themeMode.name,
+      themeIndex,
+    );
+  }
+}

--- a/packages/infrastructure/lib/src/shared_preferences/shared_preferences_keys.dart
+++ b/packages/infrastructure/lib/src/shared_preferences/shared_preferences_keys.dart
@@ -1,0 +1,3 @@
+enum SharedPreferencesKeys {
+  themeMode,
+}

--- a/packages/infrastructure/lib/src/theme_mode/theme_mode_repository_impl.dart
+++ b/packages/infrastructure/lib/src/theme_mode/theme_mode_repository_impl.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+import 'package:internal_domain_logic/internal_domain_logic.dart';
+import 'package:internal_infrastructure/src/shared_preferences/shared_preference_data_source.dart';
+
+class ThemeModeRepositoryImpl implements ThemeModeRepository {
+  const ThemeModeRepositoryImpl(this._sharedPreference);
+
+  final SharedPreferenceDataSource _sharedPreference;
+
+  @override
+  ThemeMode getThemeMode() {
+    return _sharedPreference.getThemeMode();
+  }
+
+  @override
+  Future<void> saveThemeMode(ThemeMode themeMode) async {
+    await _sharedPreference.saveThemeMode(themeMode.index);
+  }
+}

--- a/packages/infrastructure/pubspec.yaml
+++ b/packages/infrastructure/pubspec.yaml
@@ -9,10 +9,13 @@ environment:
 resolution: workspace
 
 dependencies:
+  flutter:
+    sdk: flutter
   internal_domain_logic:
     path: ../domain_logic
   internal_domain_model:
     path: ../domain_model
+  shared_preferences: ^2.3.3
 
 dev_dependencies:
   test: ^1.25.8

--- a/packages/infrastructure/pubspec.yaml
+++ b/packages/infrastructure/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
     path: ../domain_logic
   internal_domain_model:
     path: ../domain_model
-  shared_preferences: ^2.3.3
+  shared_preferences: ^2.3.5
 
 dev_dependencies:
   test: ^1.25.8


### PR DESCRIPTION
## 概要

close: #441

テーマモード（ライト/ダーク/システム）の管理機能を実装しました。
SharedPreferencesを使用してユーザーのテーマ設定を永続化し、アプリ起動時に設定を復元できるようになります。

## レビュー観点

- Domain Logic層とInfrastructure層の責務分離が適切に行われているか
- SharedPreferencesを使用したデータ永続化の実装が適切か
- ThemeModeRepositoryのインターフェース設計が適切か
- エラーハンドリングが適切に実装されているか

## レビューレベル

- [x] Lv2: 仕様レベルまで理解して、仕様通りに動くかある程度検証して Approve する

## レビュー優先度

- [x] 今日〜明日中で見てもらいたい 🚶

## 画像 / 動画

見た目に関する変更がないため省略します。

|           Before           |           After            |           Design           |
| :------------------------: | :------------------------: | :------------------------: |
| <img src="" width="300" /> | <img src="" width="300" /> | <img src="" width="300" /> |

## 確認したこと

- [x] Domain Logic層にThemeModeRepositoryインターフェースを追加
- [x] Infrastructure層にThemeModeRepositoryImplを実装
- [x] SharedPreferenceDataSourceを作成してSharedPreferencesとの連携を実装
- [x] SharedPreferencesKeysでキーを管理
- [x] 必要な依存関係をpubspec.yamlに追加
- [x] 各パッケージのexportファイルを更新

## 動作確認手順


## 備考