### PR TITLE
[GH-439] domain_model に移行

### DIFF
--- a/packages/domain_model/build.yaml
+++ b/packages/domain_model/build.yaml
@@ -10,4 +10,4 @@ targets:
           ignore_for_file:
             - type=lint
             - duplicate_ignore
-            - deprecated_member_use 
+            - deprecated_member_use

--- a/packages/domain_model/build.yaml
+++ b/packages/domain_model/build.yaml
@@ -1,0 +1,13 @@
+targets:
+  $default:
+    builders:
+      freezed:
+        generate_for:
+          include:
+            - lib/src/**.dart
+      source_gen:combining_builder:
+        options:
+          ignore_for_file:
+            - type=lint
+            - duplicate_ignore
+            - deprecated_member_use 

--- a/packages/domain_model/lib/internal_domain_model.dart
+++ b/packages/domain_model/lib/internal_domain_model.dart
@@ -3,6 +3,10 @@
 /// More dartdocs go here.
 library;
 
+export 'src/force_update_settings_state.dart';
+export 'src/force_update_target_version.dart';
 export 'src/internal_domain_model_base.dart';
+export 'src/maintenance_mode_settings_state.dart';
+export 'src/version_string.dart';
 
 // TODO: Export any libraries intended for clients of this package.

--- a/packages/domain_model/lib/src/force_update_settings_state.dart
+++ b/packages/domain_model/lib/src/force_update_settings_state.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/foundation.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:internal_domain_model/src/force_update_target_version.dart';
+import 'package:internal_domain_model/src/version_string.dart';
+
+part 'force_update_settings_state.freezed.dart';
+
+@freezed
+class ForceUpdateSettingsState with _$ForceUpdateSettingsState {
+  const factory ForceUpdateSettingsState({
+    @Default(false) bool enabled,
+  }) = _ForceUpdateSettingsState;
+
+  const ForceUpdateSettingsState._();
+
+  static bool isForceUpdateEnabled({
+    required VersionString currentVersion,
+    required ForceUpdateTargetVersion forceUpdateTargetVersion,
+  }) {
+    final targetVersion = forceUpdateTargetVersion.defaultTargetPlatformVersion;
+    if (targetVersion == null) {
+      return false;
+    }
+
+    return currentVersion < targetVersion;
+  }
+}

--- a/packages/domain_model/lib/src/force_update_settings_state.dart
+++ b/packages/domain_model/lib/src/force_update_settings_state.dart
@@ -6,7 +6,7 @@ import 'package:internal_domain_model/src/version_string.dart';
 part 'force_update_settings_state.freezed.dart';
 
 @freezed
-class ForceUpdateSettingsState with _$ForceUpdateSettingsState {
+abstract class ForceUpdateSettingsState with _$ForceUpdateSettingsState {
   const factory ForceUpdateSettingsState({
     @Default(false) bool enabled,
   }) = _ForceUpdateSettingsState;

--- a/packages/domain_model/lib/src/force_update_settings_state.freezed.dart
+++ b/packages/domain_model/lib/src/force_update_settings_state.freezed.dart
@@ -1,0 +1,160 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'force_update_settings_state.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+/// @nodoc
+mixin _$ForceUpdateSettingsState {
+  bool get enabled => throw _privateConstructorUsedError;
+
+  /// Create a copy of ForceUpdateSettingsState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $ForceUpdateSettingsStateCopyWith<ForceUpdateSettingsState> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $ForceUpdateSettingsStateCopyWith<$Res> {
+  factory $ForceUpdateSettingsStateCopyWith(ForceUpdateSettingsState value,
+          $Res Function(ForceUpdateSettingsState) then) =
+      _$ForceUpdateSettingsStateCopyWithImpl<$Res, ForceUpdateSettingsState>;
+  @useResult
+  $Res call({bool enabled});
+}
+
+/// @nodoc
+class _$ForceUpdateSettingsStateCopyWithImpl<$Res,
+        $Val extends ForceUpdateSettingsState>
+    implements $ForceUpdateSettingsStateCopyWith<$Res> {
+  _$ForceUpdateSettingsStateCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of ForceUpdateSettingsState
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? enabled = null,
+  }) {
+    return _then(_value.copyWith(
+      enabled: null == enabled
+          ? _value.enabled
+          : enabled // ignore: cast_nullable_to_non_nullable
+              as bool,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$ForceUpdateSettingsStateImplCopyWith<$Res>
+    implements $ForceUpdateSettingsStateCopyWith<$Res> {
+  factory _$$ForceUpdateSettingsStateImplCopyWith(
+          _$ForceUpdateSettingsStateImpl value,
+          $Res Function(_$ForceUpdateSettingsStateImpl) then) =
+      __$$ForceUpdateSettingsStateImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({bool enabled});
+}
+
+/// @nodoc
+class __$$ForceUpdateSettingsStateImplCopyWithImpl<$Res>
+    extends _$ForceUpdateSettingsStateCopyWithImpl<$Res,
+        _$ForceUpdateSettingsStateImpl>
+    implements _$$ForceUpdateSettingsStateImplCopyWith<$Res> {
+  __$$ForceUpdateSettingsStateImplCopyWithImpl(
+      _$ForceUpdateSettingsStateImpl _value,
+      $Res Function(_$ForceUpdateSettingsStateImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of ForceUpdateSettingsState
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? enabled = null,
+  }) {
+    return _then(_$ForceUpdateSettingsStateImpl(
+      enabled: null == enabled
+          ? _value.enabled
+          : enabled // ignore: cast_nullable_to_non_nullable
+              as bool,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$ForceUpdateSettingsStateImpl extends _ForceUpdateSettingsState
+    with DiagnosticableTreeMixin {
+  const _$ForceUpdateSettingsStateImpl({this.enabled = false}) : super._();
+
+  @override
+  @JsonKey()
+  final bool enabled;
+
+  @override
+  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) {
+    return 'ForceUpdateSettingsState(enabled: $enabled)';
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties
+      ..add(DiagnosticsProperty('type', 'ForceUpdateSettingsState'))
+      ..add(DiagnosticsProperty('enabled', enabled));
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ForceUpdateSettingsStateImpl &&
+            (identical(other.enabled, enabled) || other.enabled == enabled));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, enabled);
+
+  /// Create a copy of ForceUpdateSettingsState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$ForceUpdateSettingsStateImplCopyWith<_$ForceUpdateSettingsStateImpl>
+      get copyWith => __$$ForceUpdateSettingsStateImplCopyWithImpl<
+          _$ForceUpdateSettingsStateImpl>(this, _$identity);
+}
+
+abstract class _ForceUpdateSettingsState extends ForceUpdateSettingsState {
+  const factory _ForceUpdateSettingsState({final bool enabled}) =
+      _$ForceUpdateSettingsStateImpl;
+  const _ForceUpdateSettingsState._() : super._();
+
+  @override
+  bool get enabled;
+
+  /// Create a copy of ForceUpdateSettingsState
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$ForceUpdateSettingsStateImplCopyWith<_$ForceUpdateSettingsStateImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}

--- a/packages/domain_model/lib/src/force_update_settings_state.freezed.dart
+++ b/packages/domain_model/lib/src/force_update_settings_state.freezed.dart
@@ -12,7 +12,8 @@ part of 'force_update_settings_state.dart';
 T _$identity<T>(T value) => value;
 
 final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
+);
 
 /// @nodoc
 mixin _$ForceUpdateSettingsState {
@@ -27,16 +28,19 @@ mixin _$ForceUpdateSettingsState {
 
 /// @nodoc
 abstract class $ForceUpdateSettingsStateCopyWith<$Res> {
-  factory $ForceUpdateSettingsStateCopyWith(ForceUpdateSettingsState value,
-          $Res Function(ForceUpdateSettingsState) then) =
-      _$ForceUpdateSettingsStateCopyWithImpl<$Res, ForceUpdateSettingsState>;
+  factory $ForceUpdateSettingsStateCopyWith(
+    ForceUpdateSettingsState value,
+    $Res Function(ForceUpdateSettingsState) then,
+  ) = _$ForceUpdateSettingsStateCopyWithImpl<$Res, ForceUpdateSettingsState>;
   @useResult
   $Res call({bool enabled});
 }
 
 /// @nodoc
-class _$ForceUpdateSettingsStateCopyWithImpl<$Res,
-        $Val extends ForceUpdateSettingsState>
+class _$ForceUpdateSettingsStateCopyWithImpl<
+  $Res,
+  $Val extends ForceUpdateSettingsState
+>
     implements $ForceUpdateSettingsStateCopyWith<$Res> {
   _$ForceUpdateSettingsStateCopyWithImpl(this._value, this._then);
 
@@ -52,12 +56,15 @@ class _$ForceUpdateSettingsStateCopyWithImpl<$Res,
   $Res call({
     Object? enabled = null,
   }) {
-    return _then(_value.copyWith(
-      enabled: null == enabled
-          ? _value.enabled
-          : enabled // ignore: cast_nullable_to_non_nullable
-              as bool,
-    ) as $Val);
+    return _then(
+      _value.copyWith(
+            enabled: null == enabled
+                ? _value.enabled
+                : enabled // ignore: cast_nullable_to_non_nullable
+                      as bool,
+          )
+          as $Val,
+    );
   }
 }
 
@@ -65,9 +72,9 @@ class _$ForceUpdateSettingsStateCopyWithImpl<$Res,
 abstract class _$$ForceUpdateSettingsStateImplCopyWith<$Res>
     implements $ForceUpdateSettingsStateCopyWith<$Res> {
   factory _$$ForceUpdateSettingsStateImplCopyWith(
-          _$ForceUpdateSettingsStateImpl value,
-          $Res Function(_$ForceUpdateSettingsStateImpl) then) =
-      __$$ForceUpdateSettingsStateImplCopyWithImpl<$Res>;
+    _$ForceUpdateSettingsStateImpl value,
+    $Res Function(_$ForceUpdateSettingsStateImpl) then,
+  ) = __$$ForceUpdateSettingsStateImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({bool enabled});
@@ -75,13 +82,16 @@ abstract class _$$ForceUpdateSettingsStateImplCopyWith<$Res>
 
 /// @nodoc
 class __$$ForceUpdateSettingsStateImplCopyWithImpl<$Res>
-    extends _$ForceUpdateSettingsStateCopyWithImpl<$Res,
-        _$ForceUpdateSettingsStateImpl>
+    extends
+        _$ForceUpdateSettingsStateCopyWithImpl<
+          $Res,
+          _$ForceUpdateSettingsStateImpl
+        >
     implements _$$ForceUpdateSettingsStateImplCopyWith<$Res> {
   __$$ForceUpdateSettingsStateImplCopyWithImpl(
-      _$ForceUpdateSettingsStateImpl _value,
-      $Res Function(_$ForceUpdateSettingsStateImpl) _then)
-      : super(_value, _then);
+    _$ForceUpdateSettingsStateImpl _value,
+    $Res Function(_$ForceUpdateSettingsStateImpl) _then,
+  ) : super(_value, _then);
 
   /// Create a copy of ForceUpdateSettingsState
   /// with the given fields replaced by the non-null parameter values.
@@ -90,12 +100,14 @@ class __$$ForceUpdateSettingsStateImplCopyWithImpl<$Res>
   $Res call({
     Object? enabled = null,
   }) {
-    return _then(_$ForceUpdateSettingsStateImpl(
-      enabled: null == enabled
-          ? _value.enabled
-          : enabled // ignore: cast_nullable_to_non_nullable
-              as bool,
-    ));
+    return _then(
+      _$ForceUpdateSettingsStateImpl(
+        enabled: null == enabled
+            ? _value.enabled
+            : enabled // ignore: cast_nullable_to_non_nullable
+                  as bool,
+      ),
+    );
   }
 }
 
@@ -139,8 +151,10 @@ class _$ForceUpdateSettingsStateImpl extends _ForceUpdateSettingsState
   @override
   @pragma('vm:prefer-inline')
   _$$ForceUpdateSettingsStateImplCopyWith<_$ForceUpdateSettingsStateImpl>
-      get copyWith => __$$ForceUpdateSettingsStateImplCopyWithImpl<
-          _$ForceUpdateSettingsStateImpl>(this, _$identity);
+  get copyWith =>
+      __$$ForceUpdateSettingsStateImplCopyWithImpl<
+        _$ForceUpdateSettingsStateImpl
+      >(this, _$identity);
 }
 
 abstract class _ForceUpdateSettingsState extends ForceUpdateSettingsState {
@@ -156,5 +170,5 @@ abstract class _ForceUpdateSettingsState extends ForceUpdateSettingsState {
   @override
   @JsonKey(includeFromJson: false, includeToJson: false)
   _$$ForceUpdateSettingsStateImplCopyWith<_$ForceUpdateSettingsStateImpl>
-      get copyWith => throw _privateConstructorUsedError;
+  get copyWith => throw _privateConstructorUsedError;
 }

--- a/packages/domain_model/lib/src/force_update_settings_state.freezed.dart
+++ b/packages/domain_model/lib/src/force_update_settings_state.freezed.dart
@@ -1,3 +1,4 @@
+// dart format width=80
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint
@@ -9,166 +10,145 @@ part of 'force_update_settings_state.dart';
 // FreezedGenerator
 // **************************************************************************
 
+// dart format off
 T _$identity<T>(T value) => value;
-
-final _privateConstructorUsedError = UnsupportedError(
-  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
-);
-
 /// @nodoc
-mixin _$ForceUpdateSettingsState {
-  bool get enabled => throw _privateConstructorUsedError;
+mixin _$ForceUpdateSettingsState implements DiagnosticableTreeMixin {
 
-  /// Create a copy of ForceUpdateSettingsState
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  $ForceUpdateSettingsStateCopyWith<ForceUpdateSettingsState> get copyWith =>
-      throw _privateConstructorUsedError;
+ bool get enabled;
+/// Create a copy of ForceUpdateSettingsState
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$ForceUpdateSettingsStateCopyWith<ForceUpdateSettingsState> get copyWith => _$ForceUpdateSettingsStateCopyWithImpl<ForceUpdateSettingsState>(this as ForceUpdateSettingsState, _$identity);
+
+
+@override
+void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+  properties
+    ..add(DiagnosticsProperty('type', 'ForceUpdateSettingsState'))
+    ..add(DiagnosticsProperty('enabled', enabled));
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ForceUpdateSettingsState&&(identical(other.enabled, enabled) || other.enabled == enabled));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,enabled);
+
+@override
+String toString({ DiagnosticLevel minLevel = DiagnosticLevel.info }) {
+  return 'ForceUpdateSettingsState(enabled: $enabled)';
+}
+
+
 }
 
 /// @nodoc
-abstract class $ForceUpdateSettingsStateCopyWith<$Res> {
-  factory $ForceUpdateSettingsStateCopyWith(
-    ForceUpdateSettingsState value,
-    $Res Function(ForceUpdateSettingsState) then,
-  ) = _$ForceUpdateSettingsStateCopyWithImpl<$Res, ForceUpdateSettingsState>;
-  @useResult
-  $Res call({bool enabled});
-}
+abstract mixin class $ForceUpdateSettingsStateCopyWith<$Res>  {
+  factory $ForceUpdateSettingsStateCopyWith(ForceUpdateSettingsState value, $Res Function(ForceUpdateSettingsState) _then) = _$ForceUpdateSettingsStateCopyWithImpl;
+@useResult
+$Res call({
+ bool enabled
+});
 
+
+
+
+}
 /// @nodoc
-class _$ForceUpdateSettingsStateCopyWithImpl<
-  $Res,
-  $Val extends ForceUpdateSettingsState
->
+class _$ForceUpdateSettingsStateCopyWithImpl<$Res>
     implements $ForceUpdateSettingsStateCopyWith<$Res> {
-  _$ForceUpdateSettingsStateCopyWithImpl(this._value, this._then);
+  _$ForceUpdateSettingsStateCopyWithImpl(this._self, this._then);
 
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
+  final ForceUpdateSettingsState _self;
+  final $Res Function(ForceUpdateSettingsState) _then;
 
-  /// Create a copy of ForceUpdateSettingsState
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? enabled = null,
-  }) {
-    return _then(
-      _value.copyWith(
-            enabled: null == enabled
-                ? _value.enabled
-                : enabled // ignore: cast_nullable_to_non_nullable
-                      as bool,
-          )
-          as $Val,
-    );
-  }
+/// Create a copy of ForceUpdateSettingsState
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? enabled = null,}) {
+  return _then(_self.copyWith(
+enabled: null == enabled ? _self.enabled : enabled // ignore: cast_nullable_to_non_nullable
+as bool,
+  ));
 }
 
-/// @nodoc
-abstract class _$$ForceUpdateSettingsStateImplCopyWith<$Res>
-    implements $ForceUpdateSettingsStateCopyWith<$Res> {
-  factory _$$ForceUpdateSettingsStateImplCopyWith(
-    _$ForceUpdateSettingsStateImpl value,
-    $Res Function(_$ForceUpdateSettingsStateImpl) then,
-  ) = __$$ForceUpdateSettingsStateImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call({bool enabled});
 }
 
-/// @nodoc
-class __$$ForceUpdateSettingsStateImplCopyWithImpl<$Res>
-    extends
-        _$ForceUpdateSettingsStateCopyWithImpl<
-          $Res,
-          _$ForceUpdateSettingsStateImpl
-        >
-    implements _$$ForceUpdateSettingsStateImplCopyWith<$Res> {
-  __$$ForceUpdateSettingsStateImplCopyWithImpl(
-    _$ForceUpdateSettingsStateImpl _value,
-    $Res Function(_$ForceUpdateSettingsStateImpl) _then,
-  ) : super(_value, _then);
-
-  /// Create a copy of ForceUpdateSettingsState
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? enabled = null,
-  }) {
-    return _then(
-      _$ForceUpdateSettingsStateImpl(
-        enabled: null == enabled
-            ? _value.enabled
-            : enabled // ignore: cast_nullable_to_non_nullable
-                  as bool,
-      ),
-    );
-  }
-}
 
 /// @nodoc
 
-class _$ForceUpdateSettingsStateImpl extends _ForceUpdateSettingsState
-    with DiagnosticableTreeMixin {
-  const _$ForceUpdateSettingsStateImpl({this.enabled = false}) : super._();
 
-  @override
-  @JsonKey()
-  final bool enabled;
+class _ForceUpdateSettingsState extends ForceUpdateSettingsState with DiagnosticableTreeMixin {
+  const _ForceUpdateSettingsState({this.enabled = false}): super._();
+  
 
-  @override
-  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) {
-    return 'ForceUpdateSettingsState(enabled: $enabled)';
-  }
+@override@JsonKey() final  bool enabled;
 
-  @override
-  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
-    super.debugFillProperties(properties);
-    properties
-      ..add(DiagnosticsProperty('type', 'ForceUpdateSettingsState'))
-      ..add(DiagnosticsProperty('enabled', enabled));
-  }
+/// Create a copy of ForceUpdateSettingsState
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$ForceUpdateSettingsStateCopyWith<_ForceUpdateSettingsState> get copyWith => __$ForceUpdateSettingsStateCopyWithImpl<_ForceUpdateSettingsState>(this, _$identity);
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _$ForceUpdateSettingsStateImpl &&
-            (identical(other.enabled, enabled) || other.enabled == enabled));
-  }
 
-  @override
-  int get hashCode => Object.hash(runtimeType, enabled);
-
-  /// Create a copy of ForceUpdateSettingsState
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  @pragma('vm:prefer-inline')
-  _$$ForceUpdateSettingsStateImplCopyWith<_$ForceUpdateSettingsStateImpl>
-  get copyWith =>
-      __$$ForceUpdateSettingsStateImplCopyWithImpl<
-        _$ForceUpdateSettingsStateImpl
-      >(this, _$identity);
+@override
+void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+  properties
+    ..add(DiagnosticsProperty('type', 'ForceUpdateSettingsState'))
+    ..add(DiagnosticsProperty('enabled', enabled));
 }
 
-abstract class _ForceUpdateSettingsState extends ForceUpdateSettingsState {
-  const factory _ForceUpdateSettingsState({final bool enabled}) =
-      _$ForceUpdateSettingsStateImpl;
-  const _ForceUpdateSettingsState._() : super._();
-
-  @override
-  bool get enabled;
-
-  /// Create a copy of ForceUpdateSettingsState
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$ForceUpdateSettingsStateImplCopyWith<_$ForceUpdateSettingsStateImpl>
-  get copyWith => throw _privateConstructorUsedError;
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _ForceUpdateSettingsState&&(identical(other.enabled, enabled) || other.enabled == enabled));
 }
+
+
+@override
+int get hashCode => Object.hash(runtimeType,enabled);
+
+@override
+String toString({ DiagnosticLevel minLevel = DiagnosticLevel.info }) {
+  return 'ForceUpdateSettingsState(enabled: $enabled)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$ForceUpdateSettingsStateCopyWith<$Res> implements $ForceUpdateSettingsStateCopyWith<$Res> {
+  factory _$ForceUpdateSettingsStateCopyWith(_ForceUpdateSettingsState value, $Res Function(_ForceUpdateSettingsState) _then) = __$ForceUpdateSettingsStateCopyWithImpl;
+@override @useResult
+$Res call({
+ bool enabled
+});
+
+
+
+
+}
+/// @nodoc
+class __$ForceUpdateSettingsStateCopyWithImpl<$Res>
+    implements _$ForceUpdateSettingsStateCopyWith<$Res> {
+  __$ForceUpdateSettingsStateCopyWithImpl(this._self, this._then);
+
+  final _ForceUpdateSettingsState _self;
+  final $Res Function(_ForceUpdateSettingsState) _then;
+
+/// Create a copy of ForceUpdateSettingsState
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? enabled = null,}) {
+  return _then(_ForceUpdateSettingsState(
+enabled: null == enabled ? _self.enabled : enabled // ignore: cast_nullable_to_non_nullable
+as bool,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/packages/domain_model/lib/src/force_update_target_version.dart
+++ b/packages/domain_model/lib/src/force_update_target_version.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/foundation.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:internal_domain_model/src/version_string.dart';
+
+part 'force_update_target_version.freezed.dart';
+
+@freezed
+class ForceUpdateTargetVersion with _$ForceUpdateTargetVersion {
+  const factory ForceUpdateTargetVersion({
+    required VersionString ios,
+    required VersionString android,
+  }) = _ForceUpdateTargetVersion;
+
+  const ForceUpdateTargetVersion._();
+
+  VersionString? get defaultTargetPlatformVersion {
+    return switch (defaultTargetPlatform) {
+      TargetPlatform.android => android,
+      TargetPlatform.iOS => ios,
+      _ => null,
+    };
+  }
+}

--- a/packages/domain_model/lib/src/force_update_target_version.dart
+++ b/packages/domain_model/lib/src/force_update_target_version.dart
@@ -5,7 +5,7 @@ import 'package:internal_domain_model/src/version_string.dart';
 part 'force_update_target_version.freezed.dart';
 
 @freezed
-class ForceUpdateTargetVersion with _$ForceUpdateTargetVersion {
+abstract class ForceUpdateTargetVersion with _$ForceUpdateTargetVersion {
   const factory ForceUpdateTargetVersion({
     required VersionString ios,
     required VersionString android,
@@ -19,5 +19,16 @@ class ForceUpdateTargetVersion with _$ForceUpdateTargetVersion {
       TargetPlatform.iOS => ios,
       _ => null,
     };
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(
+      DiagnosticsProperty<VersionString?>(
+        'defaultTargetPlatformVersion',
+        defaultTargetPlatformVersion,
+      ),
+    );
   }
 }

--- a/packages/domain_model/lib/src/force_update_target_version.freezed.dart
+++ b/packages/domain_model/lib/src/force_update_target_version.freezed.dart
@@ -1,0 +1,179 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'force_update_target_version.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+/// @nodoc
+mixin _$ForceUpdateTargetVersion {
+  VersionString get ios => throw _privateConstructorUsedError;
+  VersionString get android => throw _privateConstructorUsedError;
+
+  /// Create a copy of ForceUpdateTargetVersion
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $ForceUpdateTargetVersionCopyWith<ForceUpdateTargetVersion> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $ForceUpdateTargetVersionCopyWith<$Res> {
+  factory $ForceUpdateTargetVersionCopyWith(ForceUpdateTargetVersion value,
+          $Res Function(ForceUpdateTargetVersion) then) =
+      _$ForceUpdateTargetVersionCopyWithImpl<$Res, ForceUpdateTargetVersion>;
+  @useResult
+  $Res call({VersionString ios, VersionString android});
+}
+
+/// @nodoc
+class _$ForceUpdateTargetVersionCopyWithImpl<$Res,
+        $Val extends ForceUpdateTargetVersion>
+    implements $ForceUpdateTargetVersionCopyWith<$Res> {
+  _$ForceUpdateTargetVersionCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of ForceUpdateTargetVersion
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? ios = null,
+    Object? android = null,
+  }) {
+    return _then(_value.copyWith(
+      ios: null == ios
+          ? _value.ios
+          : ios // ignore: cast_nullable_to_non_nullable
+              as VersionString,
+      android: null == android
+          ? _value.android
+          : android // ignore: cast_nullable_to_non_nullable
+              as VersionString,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$ForceUpdateTargetVersionImplCopyWith<$Res>
+    implements $ForceUpdateTargetVersionCopyWith<$Res> {
+  factory _$$ForceUpdateTargetVersionImplCopyWith(
+          _$ForceUpdateTargetVersionImpl value,
+          $Res Function(_$ForceUpdateTargetVersionImpl) then) =
+      __$$ForceUpdateTargetVersionImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({VersionString ios, VersionString android});
+}
+
+/// @nodoc
+class __$$ForceUpdateTargetVersionImplCopyWithImpl<$Res>
+    extends _$ForceUpdateTargetVersionCopyWithImpl<$Res,
+        _$ForceUpdateTargetVersionImpl>
+    implements _$$ForceUpdateTargetVersionImplCopyWith<$Res> {
+  __$$ForceUpdateTargetVersionImplCopyWithImpl(
+      _$ForceUpdateTargetVersionImpl _value,
+      $Res Function(_$ForceUpdateTargetVersionImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of ForceUpdateTargetVersion
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? ios = null,
+    Object? android = null,
+  }) {
+    return _then(_$ForceUpdateTargetVersionImpl(
+      ios: null == ios
+          ? _value.ios
+          : ios // ignore: cast_nullable_to_non_nullable
+              as VersionString,
+      android: null == android
+          ? _value.android
+          : android // ignore: cast_nullable_to_non_nullable
+              as VersionString,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$ForceUpdateTargetVersionImpl extends _ForceUpdateTargetVersion
+    with DiagnosticableTreeMixin {
+  const _$ForceUpdateTargetVersionImpl(
+      {required this.ios, required this.android})
+      : super._();
+
+  @override
+  final VersionString ios;
+  @override
+  final VersionString android;
+
+  @override
+  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) {
+    return 'ForceUpdateTargetVersion(ios: $ios, android: $android)';
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties
+      ..add(DiagnosticsProperty('type', 'ForceUpdateTargetVersion'))
+      ..add(DiagnosticsProperty('ios', ios))
+      ..add(DiagnosticsProperty('android', android));
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ForceUpdateTargetVersionImpl &&
+            (identical(other.ios, ios) || other.ios == ios) &&
+            (identical(other.android, android) || other.android == android));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, ios, android);
+
+  /// Create a copy of ForceUpdateTargetVersion
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$ForceUpdateTargetVersionImplCopyWith<_$ForceUpdateTargetVersionImpl>
+      get copyWith => __$$ForceUpdateTargetVersionImplCopyWithImpl<
+          _$ForceUpdateTargetVersionImpl>(this, _$identity);
+}
+
+abstract class _ForceUpdateTargetVersion extends ForceUpdateTargetVersion {
+  const factory _ForceUpdateTargetVersion(
+      {required final VersionString ios,
+      required final VersionString android}) = _$ForceUpdateTargetVersionImpl;
+  const _ForceUpdateTargetVersion._() : super._();
+
+  @override
+  VersionString get ios;
+  @override
+  VersionString get android;
+
+  /// Create a copy of ForceUpdateTargetVersion
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$ForceUpdateTargetVersionImplCopyWith<_$ForceUpdateTargetVersionImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}

--- a/packages/domain_model/lib/src/force_update_target_version.freezed.dart
+++ b/packages/domain_model/lib/src/force_update_target_version.freezed.dart
@@ -1,3 +1,4 @@
+// dart format width=80
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint
@@ -9,187 +10,148 @@ part of 'force_update_target_version.dart';
 // FreezedGenerator
 // **************************************************************************
 
+// dart format off
 T _$identity<T>(T value) => value;
-
-final _privateConstructorUsedError = UnsupportedError(
-  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
-);
-
 /// @nodoc
-mixin _$ForceUpdateTargetVersion {
-  VersionString get ios => throw _privateConstructorUsedError;
-  VersionString get android => throw _privateConstructorUsedError;
+mixin _$ForceUpdateTargetVersion implements DiagnosticableTreeMixin {
 
-  /// Create a copy of ForceUpdateTargetVersion
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  $ForceUpdateTargetVersionCopyWith<ForceUpdateTargetVersion> get copyWith =>
-      throw _privateConstructorUsedError;
+ VersionString get ios; VersionString get android;
+/// Create a copy of ForceUpdateTargetVersion
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$ForceUpdateTargetVersionCopyWith<ForceUpdateTargetVersion> get copyWith => _$ForceUpdateTargetVersionCopyWithImpl<ForceUpdateTargetVersion>(this as ForceUpdateTargetVersion, _$identity);
+
+
+@override
+void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+  properties
+    ..add(DiagnosticsProperty('type', 'ForceUpdateTargetVersion'))
+    ..add(DiagnosticsProperty('ios', ios))..add(DiagnosticsProperty('android', android));
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ForceUpdateTargetVersion&&(identical(other.ios, ios) || other.ios == ios)&&(identical(other.android, android) || other.android == android));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,ios,android);
+
+@override
+String toString({ DiagnosticLevel minLevel = DiagnosticLevel.info }) {
+  return 'ForceUpdateTargetVersion(ios: $ios, android: $android)';
+}
+
+
 }
 
 /// @nodoc
-abstract class $ForceUpdateTargetVersionCopyWith<$Res> {
-  factory $ForceUpdateTargetVersionCopyWith(
-    ForceUpdateTargetVersion value,
-    $Res Function(ForceUpdateTargetVersion) then,
-  ) = _$ForceUpdateTargetVersionCopyWithImpl<$Res, ForceUpdateTargetVersion>;
-  @useResult
-  $Res call({VersionString ios, VersionString android});
-}
+abstract mixin class $ForceUpdateTargetVersionCopyWith<$Res>  {
+  factory $ForceUpdateTargetVersionCopyWith(ForceUpdateTargetVersion value, $Res Function(ForceUpdateTargetVersion) _then) = _$ForceUpdateTargetVersionCopyWithImpl;
+@useResult
+$Res call({
+ VersionString ios, VersionString android
+});
 
+
+
+
+}
 /// @nodoc
-class _$ForceUpdateTargetVersionCopyWithImpl<
-  $Res,
-  $Val extends ForceUpdateTargetVersion
->
+class _$ForceUpdateTargetVersionCopyWithImpl<$Res>
     implements $ForceUpdateTargetVersionCopyWith<$Res> {
-  _$ForceUpdateTargetVersionCopyWithImpl(this._value, this._then);
+  _$ForceUpdateTargetVersionCopyWithImpl(this._self, this._then);
 
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
+  final ForceUpdateTargetVersion _self;
+  final $Res Function(ForceUpdateTargetVersion) _then;
 
-  /// Create a copy of ForceUpdateTargetVersion
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? ios = null,
-    Object? android = null,
-  }) {
-    return _then(
-      _value.copyWith(
-            ios: null == ios
-                ? _value.ios
-                : ios // ignore: cast_nullable_to_non_nullable
-                      as VersionString,
-            android: null == android
-                ? _value.android
-                : android // ignore: cast_nullable_to_non_nullable
-                      as VersionString,
-          )
-          as $Val,
-    );
-  }
+/// Create a copy of ForceUpdateTargetVersion
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? ios = null,Object? android = null,}) {
+  return _then(_self.copyWith(
+ios: null == ios ? _self.ios : ios // ignore: cast_nullable_to_non_nullable
+as VersionString,android: null == android ? _self.android : android // ignore: cast_nullable_to_non_nullable
+as VersionString,
+  ));
 }
 
-/// @nodoc
-abstract class _$$ForceUpdateTargetVersionImplCopyWith<$Res>
-    implements $ForceUpdateTargetVersionCopyWith<$Res> {
-  factory _$$ForceUpdateTargetVersionImplCopyWith(
-    _$ForceUpdateTargetVersionImpl value,
-    $Res Function(_$ForceUpdateTargetVersionImpl) then,
-  ) = __$$ForceUpdateTargetVersionImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call({VersionString ios, VersionString android});
 }
 
-/// @nodoc
-class __$$ForceUpdateTargetVersionImplCopyWithImpl<$Res>
-    extends
-        _$ForceUpdateTargetVersionCopyWithImpl<
-          $Res,
-          _$ForceUpdateTargetVersionImpl
-        >
-    implements _$$ForceUpdateTargetVersionImplCopyWith<$Res> {
-  __$$ForceUpdateTargetVersionImplCopyWithImpl(
-    _$ForceUpdateTargetVersionImpl _value,
-    $Res Function(_$ForceUpdateTargetVersionImpl) _then,
-  ) : super(_value, _then);
-
-  /// Create a copy of ForceUpdateTargetVersion
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? ios = null,
-    Object? android = null,
-  }) {
-    return _then(
-      _$ForceUpdateTargetVersionImpl(
-        ios: null == ios
-            ? _value.ios
-            : ios // ignore: cast_nullable_to_non_nullable
-                  as VersionString,
-        android: null == android
-            ? _value.android
-            : android // ignore: cast_nullable_to_non_nullable
-                  as VersionString,
-      ),
-    );
-  }
-}
 
 /// @nodoc
 
-class _$ForceUpdateTargetVersionImpl extends _ForceUpdateTargetVersion
-    with DiagnosticableTreeMixin {
-  const _$ForceUpdateTargetVersionImpl({
-    required this.ios,
-    required this.android,
-  }) : super._();
 
-  @override
-  final VersionString ios;
-  @override
-  final VersionString android;
+class _ForceUpdateTargetVersion extends ForceUpdateTargetVersion with DiagnosticableTreeMixin {
+  const _ForceUpdateTargetVersion({required this.ios, required this.android}): super._();
+  
 
-  @override
-  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) {
-    return 'ForceUpdateTargetVersion(ios: $ios, android: $android)';
-  }
+@override final  VersionString ios;
+@override final  VersionString android;
 
-  @override
-  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
-    super.debugFillProperties(properties);
-    properties
-      ..add(DiagnosticsProperty('type', 'ForceUpdateTargetVersion'))
-      ..add(DiagnosticsProperty('ios', ios))
-      ..add(DiagnosticsProperty('android', android));
-  }
+/// Create a copy of ForceUpdateTargetVersion
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$ForceUpdateTargetVersionCopyWith<_ForceUpdateTargetVersion> get copyWith => __$ForceUpdateTargetVersionCopyWithImpl<_ForceUpdateTargetVersion>(this, _$identity);
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _$ForceUpdateTargetVersionImpl &&
-            (identical(other.ios, ios) || other.ios == ios) &&
-            (identical(other.android, android) || other.android == android));
-  }
 
-  @override
-  int get hashCode => Object.hash(runtimeType, ios, android);
-
-  /// Create a copy of ForceUpdateTargetVersion
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  @pragma('vm:prefer-inline')
-  _$$ForceUpdateTargetVersionImplCopyWith<_$ForceUpdateTargetVersionImpl>
-  get copyWith =>
-      __$$ForceUpdateTargetVersionImplCopyWithImpl<
-        _$ForceUpdateTargetVersionImpl
-      >(this, _$identity);
+@override
+void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+  properties
+    ..add(DiagnosticsProperty('type', 'ForceUpdateTargetVersion'))
+    ..add(DiagnosticsProperty('ios', ios))..add(DiagnosticsProperty('android', android));
 }
 
-abstract class _ForceUpdateTargetVersion extends ForceUpdateTargetVersion {
-  const factory _ForceUpdateTargetVersion({
-    required final VersionString ios,
-    required final VersionString android,
-  }) = _$ForceUpdateTargetVersionImpl;
-  const _ForceUpdateTargetVersion._() : super._();
-
-  @override
-  VersionString get ios;
-  @override
-  VersionString get android;
-
-  /// Create a copy of ForceUpdateTargetVersion
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$ForceUpdateTargetVersionImplCopyWith<_$ForceUpdateTargetVersionImpl>
-  get copyWith => throw _privateConstructorUsedError;
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _ForceUpdateTargetVersion&&(identical(other.ios, ios) || other.ios == ios)&&(identical(other.android, android) || other.android == android));
 }
+
+
+@override
+int get hashCode => Object.hash(runtimeType,ios,android);
+
+@override
+String toString({ DiagnosticLevel minLevel = DiagnosticLevel.info }) {
+  return 'ForceUpdateTargetVersion(ios: $ios, android: $android)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$ForceUpdateTargetVersionCopyWith<$Res> implements $ForceUpdateTargetVersionCopyWith<$Res> {
+  factory _$ForceUpdateTargetVersionCopyWith(_ForceUpdateTargetVersion value, $Res Function(_ForceUpdateTargetVersion) _then) = __$ForceUpdateTargetVersionCopyWithImpl;
+@override @useResult
+$Res call({
+ VersionString ios, VersionString android
+});
+
+
+
+
+}
+/// @nodoc
+class __$ForceUpdateTargetVersionCopyWithImpl<$Res>
+    implements _$ForceUpdateTargetVersionCopyWith<$Res> {
+  __$ForceUpdateTargetVersionCopyWithImpl(this._self, this._then);
+
+  final _ForceUpdateTargetVersion _self;
+  final $Res Function(_ForceUpdateTargetVersion) _then;
+
+/// Create a copy of ForceUpdateTargetVersion
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? ios = null,Object? android = null,}) {
+  return _then(_ForceUpdateTargetVersion(
+ios: null == ios ? _self.ios : ios // ignore: cast_nullable_to_non_nullable
+as VersionString,android: null == android ? _self.android : android // ignore: cast_nullable_to_non_nullable
+as VersionString,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/packages/domain_model/lib/src/force_update_target_version.freezed.dart
+++ b/packages/domain_model/lib/src/force_update_target_version.freezed.dart
@@ -12,7 +12,8 @@ part of 'force_update_target_version.dart';
 T _$identity<T>(T value) => value;
 
 final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
+);
 
 /// @nodoc
 mixin _$ForceUpdateTargetVersion {
@@ -28,16 +29,19 @@ mixin _$ForceUpdateTargetVersion {
 
 /// @nodoc
 abstract class $ForceUpdateTargetVersionCopyWith<$Res> {
-  factory $ForceUpdateTargetVersionCopyWith(ForceUpdateTargetVersion value,
-          $Res Function(ForceUpdateTargetVersion) then) =
-      _$ForceUpdateTargetVersionCopyWithImpl<$Res, ForceUpdateTargetVersion>;
+  factory $ForceUpdateTargetVersionCopyWith(
+    ForceUpdateTargetVersion value,
+    $Res Function(ForceUpdateTargetVersion) then,
+  ) = _$ForceUpdateTargetVersionCopyWithImpl<$Res, ForceUpdateTargetVersion>;
   @useResult
   $Res call({VersionString ios, VersionString android});
 }
 
 /// @nodoc
-class _$ForceUpdateTargetVersionCopyWithImpl<$Res,
-        $Val extends ForceUpdateTargetVersion>
+class _$ForceUpdateTargetVersionCopyWithImpl<
+  $Res,
+  $Val extends ForceUpdateTargetVersion
+>
     implements $ForceUpdateTargetVersionCopyWith<$Res> {
   _$ForceUpdateTargetVersionCopyWithImpl(this._value, this._then);
 
@@ -54,16 +58,19 @@ class _$ForceUpdateTargetVersionCopyWithImpl<$Res,
     Object? ios = null,
     Object? android = null,
   }) {
-    return _then(_value.copyWith(
-      ios: null == ios
-          ? _value.ios
-          : ios // ignore: cast_nullable_to_non_nullable
-              as VersionString,
-      android: null == android
-          ? _value.android
-          : android // ignore: cast_nullable_to_non_nullable
-              as VersionString,
-    ) as $Val);
+    return _then(
+      _value.copyWith(
+            ios: null == ios
+                ? _value.ios
+                : ios // ignore: cast_nullable_to_non_nullable
+                      as VersionString,
+            android: null == android
+                ? _value.android
+                : android // ignore: cast_nullable_to_non_nullable
+                      as VersionString,
+          )
+          as $Val,
+    );
   }
 }
 
@@ -71,9 +78,9 @@ class _$ForceUpdateTargetVersionCopyWithImpl<$Res,
 abstract class _$$ForceUpdateTargetVersionImplCopyWith<$Res>
     implements $ForceUpdateTargetVersionCopyWith<$Res> {
   factory _$$ForceUpdateTargetVersionImplCopyWith(
-          _$ForceUpdateTargetVersionImpl value,
-          $Res Function(_$ForceUpdateTargetVersionImpl) then) =
-      __$$ForceUpdateTargetVersionImplCopyWithImpl<$Res>;
+    _$ForceUpdateTargetVersionImpl value,
+    $Res Function(_$ForceUpdateTargetVersionImpl) then,
+  ) = __$$ForceUpdateTargetVersionImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({VersionString ios, VersionString android});
@@ -81,13 +88,16 @@ abstract class _$$ForceUpdateTargetVersionImplCopyWith<$Res>
 
 /// @nodoc
 class __$$ForceUpdateTargetVersionImplCopyWithImpl<$Res>
-    extends _$ForceUpdateTargetVersionCopyWithImpl<$Res,
-        _$ForceUpdateTargetVersionImpl>
+    extends
+        _$ForceUpdateTargetVersionCopyWithImpl<
+          $Res,
+          _$ForceUpdateTargetVersionImpl
+        >
     implements _$$ForceUpdateTargetVersionImplCopyWith<$Res> {
   __$$ForceUpdateTargetVersionImplCopyWithImpl(
-      _$ForceUpdateTargetVersionImpl _value,
-      $Res Function(_$ForceUpdateTargetVersionImpl) _then)
-      : super(_value, _then);
+    _$ForceUpdateTargetVersionImpl _value,
+    $Res Function(_$ForceUpdateTargetVersionImpl) _then,
+  ) : super(_value, _then);
 
   /// Create a copy of ForceUpdateTargetVersion
   /// with the given fields replaced by the non-null parameter values.
@@ -97,16 +107,18 @@ class __$$ForceUpdateTargetVersionImplCopyWithImpl<$Res>
     Object? ios = null,
     Object? android = null,
   }) {
-    return _then(_$ForceUpdateTargetVersionImpl(
-      ios: null == ios
-          ? _value.ios
-          : ios // ignore: cast_nullable_to_non_nullable
-              as VersionString,
-      android: null == android
-          ? _value.android
-          : android // ignore: cast_nullable_to_non_nullable
-              as VersionString,
-    ));
+    return _then(
+      _$ForceUpdateTargetVersionImpl(
+        ios: null == ios
+            ? _value.ios
+            : ios // ignore: cast_nullable_to_non_nullable
+                  as VersionString,
+        android: null == android
+            ? _value.android
+            : android // ignore: cast_nullable_to_non_nullable
+                  as VersionString,
+      ),
+    );
   }
 }
 
@@ -114,9 +126,10 @@ class __$$ForceUpdateTargetVersionImplCopyWithImpl<$Res>
 
 class _$ForceUpdateTargetVersionImpl extends _ForceUpdateTargetVersion
     with DiagnosticableTreeMixin {
-  const _$ForceUpdateTargetVersionImpl(
-      {required this.ios, required this.android})
-      : super._();
+  const _$ForceUpdateTargetVersionImpl({
+    required this.ios,
+    required this.android,
+  }) : super._();
 
   @override
   final VersionString ios;
@@ -155,14 +168,17 @@ class _$ForceUpdateTargetVersionImpl extends _ForceUpdateTargetVersion
   @override
   @pragma('vm:prefer-inline')
   _$$ForceUpdateTargetVersionImplCopyWith<_$ForceUpdateTargetVersionImpl>
-      get copyWith => __$$ForceUpdateTargetVersionImplCopyWithImpl<
-          _$ForceUpdateTargetVersionImpl>(this, _$identity);
+  get copyWith =>
+      __$$ForceUpdateTargetVersionImplCopyWithImpl<
+        _$ForceUpdateTargetVersionImpl
+      >(this, _$identity);
 }
 
 abstract class _ForceUpdateTargetVersion extends ForceUpdateTargetVersion {
-  const factory _ForceUpdateTargetVersion(
-      {required final VersionString ios,
-      required final VersionString android}) = _$ForceUpdateTargetVersionImpl;
+  const factory _ForceUpdateTargetVersion({
+    required final VersionString ios,
+    required final VersionString android,
+  }) = _$ForceUpdateTargetVersionImpl;
   const _ForceUpdateTargetVersion._() : super._();
 
   @override
@@ -175,5 +191,5 @@ abstract class _ForceUpdateTargetVersion extends ForceUpdateTargetVersion {
   @override
   @JsonKey(includeFromJson: false, includeToJson: false)
   _$$ForceUpdateTargetVersionImplCopyWith<_$ForceUpdateTargetVersionImpl>
-      get copyWith => throw _privateConstructorUsedError;
+  get copyWith => throw _privateConstructorUsedError;
 }

--- a/packages/domain_model/lib/src/maintenance_mode_settings_state.dart
+++ b/packages/domain_model/lib/src/maintenance_mode_settings_state.dart
@@ -1,0 +1,10 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'maintenance_mode_settings_state.freezed.dart';
+
+@freezed
+class MaintenanceModeSettingsState with _$MaintenanceModeSettingsState {
+  const factory MaintenanceModeSettingsState({
+    @Default(false) bool enabled,
+  }) = _MaintenanceModeSettingsState;
+}

--- a/packages/domain_model/lib/src/maintenance_mode_settings_state.dart
+++ b/packages/domain_model/lib/src/maintenance_mode_settings_state.dart
@@ -3,7 +3,8 @@ import 'package:freezed_annotation/freezed_annotation.dart';
 part 'maintenance_mode_settings_state.freezed.dart';
 
 @freezed
-class MaintenanceModeSettingsState with _$MaintenanceModeSettingsState {
+abstract class MaintenanceModeSettingsState
+    with _$MaintenanceModeSettingsState {
   const factory MaintenanceModeSettingsState({
     @Default(false) bool enabled,
   }) = _MaintenanceModeSettingsState;

--- a/packages/domain_model/lib/src/maintenance_mode_settings_state.freezed.dart
+++ b/packages/domain_model/lib/src/maintenance_mode_settings_state.freezed.dart
@@ -1,0 +1,156 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'maintenance_mode_settings_state.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+/// @nodoc
+mixin _$MaintenanceModeSettingsState {
+  bool get enabled => throw _privateConstructorUsedError;
+
+  /// Create a copy of MaintenanceModeSettingsState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $MaintenanceModeSettingsStateCopyWith<MaintenanceModeSettingsState>
+      get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $MaintenanceModeSettingsStateCopyWith<$Res> {
+  factory $MaintenanceModeSettingsStateCopyWith(
+          MaintenanceModeSettingsState value,
+          $Res Function(MaintenanceModeSettingsState) then) =
+      _$MaintenanceModeSettingsStateCopyWithImpl<$Res,
+          MaintenanceModeSettingsState>;
+  @useResult
+  $Res call({bool enabled});
+}
+
+/// @nodoc
+class _$MaintenanceModeSettingsStateCopyWithImpl<$Res,
+        $Val extends MaintenanceModeSettingsState>
+    implements $MaintenanceModeSettingsStateCopyWith<$Res> {
+  _$MaintenanceModeSettingsStateCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of MaintenanceModeSettingsState
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? enabled = null,
+  }) {
+    return _then(_value.copyWith(
+      enabled: null == enabled
+          ? _value.enabled
+          : enabled // ignore: cast_nullable_to_non_nullable
+              as bool,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$MaintenanceModeSettingsStateImplCopyWith<$Res>
+    implements $MaintenanceModeSettingsStateCopyWith<$Res> {
+  factory _$$MaintenanceModeSettingsStateImplCopyWith(
+          _$MaintenanceModeSettingsStateImpl value,
+          $Res Function(_$MaintenanceModeSettingsStateImpl) then) =
+      __$$MaintenanceModeSettingsStateImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({bool enabled});
+}
+
+/// @nodoc
+class __$$MaintenanceModeSettingsStateImplCopyWithImpl<$Res>
+    extends _$MaintenanceModeSettingsStateCopyWithImpl<$Res,
+        _$MaintenanceModeSettingsStateImpl>
+    implements _$$MaintenanceModeSettingsStateImplCopyWith<$Res> {
+  __$$MaintenanceModeSettingsStateImplCopyWithImpl(
+      _$MaintenanceModeSettingsStateImpl _value,
+      $Res Function(_$MaintenanceModeSettingsStateImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of MaintenanceModeSettingsState
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? enabled = null,
+  }) {
+    return _then(_$MaintenanceModeSettingsStateImpl(
+      enabled: null == enabled
+          ? _value.enabled
+          : enabled // ignore: cast_nullable_to_non_nullable
+              as bool,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$MaintenanceModeSettingsStateImpl
+    implements _MaintenanceModeSettingsState {
+  const _$MaintenanceModeSettingsStateImpl({this.enabled = false});
+
+  @override
+  @JsonKey()
+  final bool enabled;
+
+  @override
+  String toString() {
+    return 'MaintenanceModeSettingsState(enabled: $enabled)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$MaintenanceModeSettingsStateImpl &&
+            (identical(other.enabled, enabled) || other.enabled == enabled));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, enabled);
+
+  /// Create a copy of MaintenanceModeSettingsState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$MaintenanceModeSettingsStateImplCopyWith<
+          _$MaintenanceModeSettingsStateImpl>
+      get copyWith => __$$MaintenanceModeSettingsStateImplCopyWithImpl<
+          _$MaintenanceModeSettingsStateImpl>(this, _$identity);
+}
+
+abstract class _MaintenanceModeSettingsState
+    implements MaintenanceModeSettingsState {
+  const factory _MaintenanceModeSettingsState({final bool enabled}) =
+      _$MaintenanceModeSettingsStateImpl;
+
+  @override
+  bool get enabled;
+
+  /// Create a copy of MaintenanceModeSettingsState
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$MaintenanceModeSettingsStateImplCopyWith<
+          _$MaintenanceModeSettingsStateImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}

--- a/packages/domain_model/lib/src/maintenance_mode_settings_state.freezed.dart
+++ b/packages/domain_model/lib/src/maintenance_mode_settings_state.freezed.dart
@@ -12,7 +12,8 @@ part of 'maintenance_mode_settings_state.dart';
 T _$identity<T>(T value) => value;
 
 final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
+);
 
 /// @nodoc
 mixin _$MaintenanceModeSettingsState {
@@ -22,23 +23,28 @@ mixin _$MaintenanceModeSettingsState {
   /// with the given fields replaced by the non-null parameter values.
   @JsonKey(includeFromJson: false, includeToJson: false)
   $MaintenanceModeSettingsStateCopyWith<MaintenanceModeSettingsState>
-      get copyWith => throw _privateConstructorUsedError;
+  get copyWith => throw _privateConstructorUsedError;
 }
 
 /// @nodoc
 abstract class $MaintenanceModeSettingsStateCopyWith<$Res> {
   factory $MaintenanceModeSettingsStateCopyWith(
-          MaintenanceModeSettingsState value,
-          $Res Function(MaintenanceModeSettingsState) then) =
-      _$MaintenanceModeSettingsStateCopyWithImpl<$Res,
-          MaintenanceModeSettingsState>;
+    MaintenanceModeSettingsState value,
+    $Res Function(MaintenanceModeSettingsState) then,
+  ) =
+      _$MaintenanceModeSettingsStateCopyWithImpl<
+        $Res,
+        MaintenanceModeSettingsState
+      >;
   @useResult
   $Res call({bool enabled});
 }
 
 /// @nodoc
-class _$MaintenanceModeSettingsStateCopyWithImpl<$Res,
-        $Val extends MaintenanceModeSettingsState>
+class _$MaintenanceModeSettingsStateCopyWithImpl<
+  $Res,
+  $Val extends MaintenanceModeSettingsState
+>
     implements $MaintenanceModeSettingsStateCopyWith<$Res> {
   _$MaintenanceModeSettingsStateCopyWithImpl(this._value, this._then);
 
@@ -54,12 +60,15 @@ class _$MaintenanceModeSettingsStateCopyWithImpl<$Res,
   $Res call({
     Object? enabled = null,
   }) {
-    return _then(_value.copyWith(
-      enabled: null == enabled
-          ? _value.enabled
-          : enabled // ignore: cast_nullable_to_non_nullable
-              as bool,
-    ) as $Val);
+    return _then(
+      _value.copyWith(
+            enabled: null == enabled
+                ? _value.enabled
+                : enabled // ignore: cast_nullable_to_non_nullable
+                      as bool,
+          )
+          as $Val,
+    );
   }
 }
 
@@ -67,9 +76,9 @@ class _$MaintenanceModeSettingsStateCopyWithImpl<$Res,
 abstract class _$$MaintenanceModeSettingsStateImplCopyWith<$Res>
     implements $MaintenanceModeSettingsStateCopyWith<$Res> {
   factory _$$MaintenanceModeSettingsStateImplCopyWith(
-          _$MaintenanceModeSettingsStateImpl value,
-          $Res Function(_$MaintenanceModeSettingsStateImpl) then) =
-      __$$MaintenanceModeSettingsStateImplCopyWithImpl<$Res>;
+    _$MaintenanceModeSettingsStateImpl value,
+    $Res Function(_$MaintenanceModeSettingsStateImpl) then,
+  ) = __$$MaintenanceModeSettingsStateImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({bool enabled});
@@ -77,13 +86,16 @@ abstract class _$$MaintenanceModeSettingsStateImplCopyWith<$Res>
 
 /// @nodoc
 class __$$MaintenanceModeSettingsStateImplCopyWithImpl<$Res>
-    extends _$MaintenanceModeSettingsStateCopyWithImpl<$Res,
-        _$MaintenanceModeSettingsStateImpl>
+    extends
+        _$MaintenanceModeSettingsStateCopyWithImpl<
+          $Res,
+          _$MaintenanceModeSettingsStateImpl
+        >
     implements _$$MaintenanceModeSettingsStateImplCopyWith<$Res> {
   __$$MaintenanceModeSettingsStateImplCopyWithImpl(
-      _$MaintenanceModeSettingsStateImpl _value,
-      $Res Function(_$MaintenanceModeSettingsStateImpl) _then)
-      : super(_value, _then);
+    _$MaintenanceModeSettingsStateImpl _value,
+    $Res Function(_$MaintenanceModeSettingsStateImpl) _then,
+  ) : super(_value, _then);
 
   /// Create a copy of MaintenanceModeSettingsState
   /// with the given fields replaced by the non-null parameter values.
@@ -92,12 +104,14 @@ class __$$MaintenanceModeSettingsStateImplCopyWithImpl<$Res>
   $Res call({
     Object? enabled = null,
   }) {
-    return _then(_$MaintenanceModeSettingsStateImpl(
-      enabled: null == enabled
-          ? _value.enabled
-          : enabled // ignore: cast_nullable_to_non_nullable
-              as bool,
-    ));
+    return _then(
+      _$MaintenanceModeSettingsStateImpl(
+        enabled: null == enabled
+            ? _value.enabled
+            : enabled // ignore: cast_nullable_to_non_nullable
+                  as bool,
+      ),
+    );
   }
 }
 
@@ -133,9 +147,12 @@ class _$MaintenanceModeSettingsStateImpl
   @override
   @pragma('vm:prefer-inline')
   _$$MaintenanceModeSettingsStateImplCopyWith<
-          _$MaintenanceModeSettingsStateImpl>
-      get copyWith => __$$MaintenanceModeSettingsStateImplCopyWithImpl<
-          _$MaintenanceModeSettingsStateImpl>(this, _$identity);
+    _$MaintenanceModeSettingsStateImpl
+  >
+  get copyWith =>
+      __$$MaintenanceModeSettingsStateImplCopyWithImpl<
+        _$MaintenanceModeSettingsStateImpl
+      >(this, _$identity);
 }
 
 abstract class _MaintenanceModeSettingsState
@@ -151,6 +168,7 @@ abstract class _MaintenanceModeSettingsState
   @override
   @JsonKey(includeFromJson: false, includeToJson: false)
   _$$MaintenanceModeSettingsStateImplCopyWith<
-          _$MaintenanceModeSettingsStateImpl>
-      get copyWith => throw _privateConstructorUsedError;
+    _$MaintenanceModeSettingsStateImpl
+  >
+  get copyWith => throw _privateConstructorUsedError;
 }

--- a/packages/domain_model/lib/src/maintenance_mode_settings_state.freezed.dart
+++ b/packages/domain_model/lib/src/maintenance_mode_settings_state.freezed.dart
@@ -1,3 +1,4 @@
+// dart format width=80
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint
@@ -9,166 +10,133 @@ part of 'maintenance_mode_settings_state.dart';
 // FreezedGenerator
 // **************************************************************************
 
+// dart format off
 T _$identity<T>(T value) => value;
-
-final _privateConstructorUsedError = UnsupportedError(
-  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
-);
-
 /// @nodoc
 mixin _$MaintenanceModeSettingsState {
-  bool get enabled => throw _privateConstructorUsedError;
 
-  /// Create a copy of MaintenanceModeSettingsState
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  $MaintenanceModeSettingsStateCopyWith<MaintenanceModeSettingsState>
-  get copyWith => throw _privateConstructorUsedError;
+ bool get enabled;
+/// Create a copy of MaintenanceModeSettingsState
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$MaintenanceModeSettingsStateCopyWith<MaintenanceModeSettingsState> get copyWith => _$MaintenanceModeSettingsStateCopyWithImpl<MaintenanceModeSettingsState>(this as MaintenanceModeSettingsState, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is MaintenanceModeSettingsState&&(identical(other.enabled, enabled) || other.enabled == enabled));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,enabled);
+
+@override
+String toString() {
+  return 'MaintenanceModeSettingsState(enabled: $enabled)';
+}
+
+
 }
 
 /// @nodoc
-abstract class $MaintenanceModeSettingsStateCopyWith<$Res> {
-  factory $MaintenanceModeSettingsStateCopyWith(
-    MaintenanceModeSettingsState value,
-    $Res Function(MaintenanceModeSettingsState) then,
-  ) =
-      _$MaintenanceModeSettingsStateCopyWithImpl<
-        $Res,
-        MaintenanceModeSettingsState
-      >;
-  @useResult
-  $Res call({bool enabled});
-}
+abstract mixin class $MaintenanceModeSettingsStateCopyWith<$Res>  {
+  factory $MaintenanceModeSettingsStateCopyWith(MaintenanceModeSettingsState value, $Res Function(MaintenanceModeSettingsState) _then) = _$MaintenanceModeSettingsStateCopyWithImpl;
+@useResult
+$Res call({
+ bool enabled
+});
 
+
+
+
+}
 /// @nodoc
-class _$MaintenanceModeSettingsStateCopyWithImpl<
-  $Res,
-  $Val extends MaintenanceModeSettingsState
->
+class _$MaintenanceModeSettingsStateCopyWithImpl<$Res>
     implements $MaintenanceModeSettingsStateCopyWith<$Res> {
-  _$MaintenanceModeSettingsStateCopyWithImpl(this._value, this._then);
+  _$MaintenanceModeSettingsStateCopyWithImpl(this._self, this._then);
 
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
+  final MaintenanceModeSettingsState _self;
+  final $Res Function(MaintenanceModeSettingsState) _then;
 
-  /// Create a copy of MaintenanceModeSettingsState
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? enabled = null,
-  }) {
-    return _then(
-      _value.copyWith(
-            enabled: null == enabled
-                ? _value.enabled
-                : enabled // ignore: cast_nullable_to_non_nullable
-                      as bool,
-          )
-          as $Val,
-    );
-  }
+/// Create a copy of MaintenanceModeSettingsState
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? enabled = null,}) {
+  return _then(_self.copyWith(
+enabled: null == enabled ? _self.enabled : enabled // ignore: cast_nullable_to_non_nullable
+as bool,
+  ));
 }
 
-/// @nodoc
-abstract class _$$MaintenanceModeSettingsStateImplCopyWith<$Res>
-    implements $MaintenanceModeSettingsStateCopyWith<$Res> {
-  factory _$$MaintenanceModeSettingsStateImplCopyWith(
-    _$MaintenanceModeSettingsStateImpl value,
-    $Res Function(_$MaintenanceModeSettingsStateImpl) then,
-  ) = __$$MaintenanceModeSettingsStateImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call({bool enabled});
 }
 
-/// @nodoc
-class __$$MaintenanceModeSettingsStateImplCopyWithImpl<$Res>
-    extends
-        _$MaintenanceModeSettingsStateCopyWithImpl<
-          $Res,
-          _$MaintenanceModeSettingsStateImpl
-        >
-    implements _$$MaintenanceModeSettingsStateImplCopyWith<$Res> {
-  __$$MaintenanceModeSettingsStateImplCopyWithImpl(
-    _$MaintenanceModeSettingsStateImpl _value,
-    $Res Function(_$MaintenanceModeSettingsStateImpl) _then,
-  ) : super(_value, _then);
-
-  /// Create a copy of MaintenanceModeSettingsState
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? enabled = null,
-  }) {
-    return _then(
-      _$MaintenanceModeSettingsStateImpl(
-        enabled: null == enabled
-            ? _value.enabled
-            : enabled // ignore: cast_nullable_to_non_nullable
-                  as bool,
-      ),
-    );
-  }
-}
 
 /// @nodoc
 
-class _$MaintenanceModeSettingsStateImpl
-    implements _MaintenanceModeSettingsState {
-  const _$MaintenanceModeSettingsStateImpl({this.enabled = false});
 
-  @override
-  @JsonKey()
-  final bool enabled;
+class _MaintenanceModeSettingsState implements MaintenanceModeSettingsState {
+  const _MaintenanceModeSettingsState({this.enabled = false});
+  
 
-  @override
-  String toString() {
-    return 'MaintenanceModeSettingsState(enabled: $enabled)';
-  }
+@override@JsonKey() final  bool enabled;
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _$MaintenanceModeSettingsStateImpl &&
-            (identical(other.enabled, enabled) || other.enabled == enabled));
-  }
+/// Create a copy of MaintenanceModeSettingsState
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$MaintenanceModeSettingsStateCopyWith<_MaintenanceModeSettingsState> get copyWith => __$MaintenanceModeSettingsStateCopyWithImpl<_MaintenanceModeSettingsState>(this, _$identity);
 
-  @override
-  int get hashCode => Object.hash(runtimeType, enabled);
 
-  /// Create a copy of MaintenanceModeSettingsState
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  @pragma('vm:prefer-inline')
-  _$$MaintenanceModeSettingsStateImplCopyWith<
-    _$MaintenanceModeSettingsStateImpl
-  >
-  get copyWith =>
-      __$$MaintenanceModeSettingsStateImplCopyWithImpl<
-        _$MaintenanceModeSettingsStateImpl
-      >(this, _$identity);
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _MaintenanceModeSettingsState&&(identical(other.enabled, enabled) || other.enabled == enabled));
 }
 
-abstract class _MaintenanceModeSettingsState
-    implements MaintenanceModeSettingsState {
-  const factory _MaintenanceModeSettingsState({final bool enabled}) =
-      _$MaintenanceModeSettingsStateImpl;
 
-  @override
-  bool get enabled;
+@override
+int get hashCode => Object.hash(runtimeType,enabled);
 
-  /// Create a copy of MaintenanceModeSettingsState
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$MaintenanceModeSettingsStateImplCopyWith<
-    _$MaintenanceModeSettingsStateImpl
-  >
-  get copyWith => throw _privateConstructorUsedError;
+@override
+String toString() {
+  return 'MaintenanceModeSettingsState(enabled: $enabled)';
 }
+
+
+}
+
+/// @nodoc
+abstract mixin class _$MaintenanceModeSettingsStateCopyWith<$Res> implements $MaintenanceModeSettingsStateCopyWith<$Res> {
+  factory _$MaintenanceModeSettingsStateCopyWith(_MaintenanceModeSettingsState value, $Res Function(_MaintenanceModeSettingsState) _then) = __$MaintenanceModeSettingsStateCopyWithImpl;
+@override @useResult
+$Res call({
+ bool enabled
+});
+
+
+
+
+}
+/// @nodoc
+class __$MaintenanceModeSettingsStateCopyWithImpl<$Res>
+    implements _$MaintenanceModeSettingsStateCopyWith<$Res> {
+  __$MaintenanceModeSettingsStateCopyWithImpl(this._self, this._then);
+
+  final _MaintenanceModeSettingsState _self;
+  final $Res Function(_MaintenanceModeSettingsState) _then;
+
+/// Create a copy of MaintenanceModeSettingsState
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? enabled = null,}) {
+  return _then(_MaintenanceModeSettingsState(
+enabled: null == enabled ? _self.enabled : enabled // ignore: cast_nullable_to_non_nullable
+as bool,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/packages/domain_model/lib/src/version_string.dart
+++ b/packages/domain_model/lib/src/version_string.dart
@@ -1,0 +1,37 @@
+extension type VersionString(String value) {
+  static final empty = VersionString('');
+
+  /// Example: '1.0.9' -> [1, 0, 9]
+  List<int> get versionList {
+    final versionParts = value.split('.');
+
+    if (versionParts.length != 3) {
+      return [0, 0, 0];
+    }
+
+    try {
+      return versionParts.map(int.parse).toList();
+    } on FormatException catch (_) {
+      return [0, 0, 0];
+    }
+  }
+
+  bool operator >(VersionString other) {
+    final selfVersionList = versionList;
+    final otherVersionList = other.versionList;
+    for (var i = 0; i < 3; ++i) {
+      if (selfVersionList[i] > otherVersionList[i]) {
+        return true;
+      } else if (selfVersionList[i] < otherVersionList[i]) {
+        return false;
+      }
+    }
+    return false;
+  }
+
+  bool operator <(VersionString other) => other > this;
+
+  bool operator >=(VersionString other) => this > other || this == other;
+
+  bool operator <=(VersionString other) => this < other || this == other;
+}

--- a/packages/domain_model/pubspec.yaml
+++ b/packages/domain_model/pubspec.yaml
@@ -11,9 +11,9 @@ resolution: workspace
 dependencies:
   flutter:
     sdk: flutter
-  freezed_annotation: ^2.4.4
+  freezed_annotation: ^3.0.0
 
 dev_dependencies:
   build_runner: ^2.4.15
-  freezed: ^2.5.7
-  test: ^1.25.8
+  freezed: ^3.0.6
+  test: ^1.25.15

--- a/packages/domain_model/pubspec.yaml
+++ b/packages/domain_model/pubspec.yaml
@@ -8,5 +8,12 @@ environment:
 
 resolution: workspace
 
+dependencies:
+  flutter:
+    sdk: flutter
+  freezed_annotation: ^2.4.4
+
 dev_dependencies:
-  test: ^1.25.15
+  build_runner: ^2.4.15
+  freezed: ^2.5.7
+  test: ^1.25.8


### PR DESCRIPTION
## 概要

close: #439

アプリの強制アップデートとメンテナンスモード機能に必要なドメインモデルを追加しました。

主な追加項目：
- `ForceUpdateSettingsState` - 強制アップデート設定の状態管理
- `ForceUpdateTargetVersion` - 強制アップデート対象バージョンの管理
- `MaintenanceModeSettingsState` - メンテナンスモード設定の状態管理  
- `VersionString` - バージョン文字列の比較機能付きextension type

## レビュー観点

- ドメインモデルの設計が適切かどうか
- 強制アップデート判定ロジック（`ForceUpdateSettingsState.isForceUpdateEnabled`）の妥当性
- `VersionString`のバージョン比較演算子の実装
- Freezedの使用方法とビルド設定

## レビューレベル

- [x] Lv2: 仕様レベルまで理解して、仕様通りに動くかある程度検証して Approve する

## レビュー優先度

- [x] 今日〜明日中で見てもらいたい 🚶

## 画像 / 動画

見た目に関する変更がないため省略します。

## 確認したこと

- [x] Freezedによるコード生成が正常に動作すること
- [x] `VersionString`のバージョン比較が正しく動作すること
- [x] 新しいモデルがinternal_domain_model.dartからexportされていること
- [x] ビルド設定（build.yaml）が適切に設定されていること

## 動作確認手順


## 備考

このPRではドメインモデルの追加のみで、実際の機能実装は別PRで行います。