### PR TITLE
refactor: shakeパッケージをshake_gestureパッケージに置き換え

### DIFF
--- a/apps/app/ios/Podfile.lock
+++ b/apps/app/ios/Podfile.lock
@@ -13,7 +13,7 @@ PODS:
   - path_provider_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
-  - sensors_plus (0.0.1):
+  - shake_gesture_ios (0.0.1):
     - Flutter
   - share_plus (0.0.1):
     - Flutter
@@ -28,7 +28,7 @@ DEPENDENCIES:
   - flutter_inappwebview_ios (from `.symlinks/plugins/flutter_inappwebview_ios/ios`)
   - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
   - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)
-  - sensors_plus (from `.symlinks/plugins/sensors_plus/ios`)
+  - shake_gesture_ios (from `.symlinks/plugins/shake_gesture_ios/ios`)
   - share_plus (from `.symlinks/plugins/share_plus/ios`)
   - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
   - url_launcher_ios (from `.symlinks/plugins/url_launcher_ios/ios`)
@@ -46,8 +46,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/package_info_plus/ios"
   path_provider_foundation:
     :path: ".symlinks/plugins/path_provider_foundation/darwin"
-  sensors_plus:
-    :path: ".symlinks/plugins/sensors_plus/ios"
+  shake_gesture_ios:
+    :path: ".symlinks/plugins/shake_gesture_ios/ios"
   share_plus:
     :path: ".symlinks/plugins/share_plus/ios"
   shared_preferences_foundation:
@@ -61,7 +61,7 @@ SPEC CHECKSUMS:
   OrderedSet: e539b66b644ff081c73a262d24ad552a69be3a94
   package_info_plus: af8e2ca6888548050f16fa2f1938db7b5a5df499
   path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
-  sensors_plus: 6a11ed0c2e1d0bd0b20b4029d3bad27d96e0c65b
+  shake_gesture_ios: 85dce5e26785da11cf73e0234a5f4028f69afeef
   share_plus: 50da8cb520a8f0f65671c6c6a99b3617ed10a58a
   shared_preferences_foundation: 9e1978ff2562383bd5676f64ec4e9aa8fa06a6f7
   url_launcher_ios: 694010445543906933d732453a59da0a173ae33d

--- a/packages/debug/lib/src/ui/shake_detection.dart
+++ b/packages/debug/lib/src/ui/shake_detection.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:shake/shake.dart';
+import 'package:shake_gesture/shake_gesture.dart';
 
-class ShakeDetection extends StatefulWidget {
+class ShakeDetection extends StatelessWidget {
   const ShakeDetection({
     required this.onShake,
     required this.child,
@@ -20,30 +20,10 @@ class ShakeDetection extends StatefulWidget {
   }
 
   @override
-  State<ShakeDetection> createState() => _ShakeDetectionState();
-}
-
-class _ShakeDetectionState extends State<ShakeDetection> {
-  ShakeDetector? _detector;
-
-  @override
-  void initState() {
-    super.initState();
-    _detector = ShakeDetector.autoStart(
-      onPhoneShake: (_) {
-        widget.onShake();
-      },
-    );
-  }
-
-  @override
-  void dispose() {
-    _detector?.stopListening();
-    super.dispose();
-  }
-
-  @override
   Widget build(BuildContext context) {
-    return widget.child;
+    return ShakeGesture(
+      onShake: onShake,
+      child: child,
+    );
   }
 }

--- a/packages/debug/pubspec.yaml
+++ b/packages/debug/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
   go_router: ^15.1.2
   path: ^1.9.1
   riverpod_annotation: ^2.6.1
-  shake: ^3.0.0
+  shake_gesture: ^1.2.0
   talker_flutter: ^4.8.2
 
 dev_dependencies:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1021,30 +1021,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.28.0"
-  sensors_plus:
+  shake_gesture:
     dependency: transitive
     description:
-      name: sensors_plus
-      sha256: "905282c917c6bb731c242f928665c2ea15445aa491249dea9d98d7c79dc8fd39"
+      name: shake_gesture
+      sha256: "17c360aeaddee2367752a30d5165e6a787625414358c695482176010e11842c3"
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.1"
-  sensors_plus_platform_interface:
+    version: "1.2.0"
+  shake_gesture_android:
     dependency: transitive
     description:
-      name: sensors_plus_platform_interface
-      sha256: "58815d2f5e46c0c41c40fb39375d3f127306f7742efe3b891c0b1c87e2b5cd5d"
+      name: shake_gesture_android
+      sha256: "8b6751bbeea8b357cab22d599308d087975297d0694599d83acc3f7e508f63ab"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
-  shake:
+    version: "1.1.5"
+  shake_gesture_ios:
     dependency: transitive
     description:
-      name: shake
-      sha256: "7bb2bd14e9cd23a0d569f8a286b2b63ba1552ac348914d2d41ec757117ddda4e"
+      name: shake_gesture_ios
+      sha256: dd7d5a89587f3696d2abe45d35c350e9986ebaa723538892e6da91d4c7e092d5
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.0"
+    version: "1.0.2"
+  shake_gesture_platform_interface:
+    dependency: transitive
+    description:
+      name: shake_gesture_platform_interface
+      sha256: c5e9adef94892c16e030aabd2c480620cac4dfc002f397309e796248a2a397cc
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.1"
   share_plus:
     dependency: transitive
     description:


### PR DESCRIPTION
## 概要

shake パッケージだと、iOS Simulator での Shake に反応しないため shake_gesture パッケージに置き換えました。shake_gesture パッケージはより軽量で効率的な shake 検出を提供し、コードの簡素化も実現できます。

## レビュー観点

- shake_gesture パッケージへの置き換えが適切に行われているか
- 実装の簡素化（StatefulWidget から StatelessWidget への変更）が適切か
- 依存関係の更新が正しく行われているか

## レビューレベル

- [x] Lv1: ぱっとみて違和感がないかチェックして Approve する
- [ ] Lv2: 仕様レベルまで理解して、仕様通りに動くかある程度検証して Approve する
- [ ] Lv3: 実際に環境で動作確認したうえで Approve する

## レビュー優先度

- [ ] すぐに見てもらいたい ( hotfix など ) 🚀
- [ ] 今日中に見てもらいたい 🚗
- [ ] 今日〜明日中で見てもらいたい 🚶
- [x] 数日以内で見てもらいたい 🐢

## 画像 / 動画

動作確認できました！

https://github.com/user-attachments/assets/506f5f09-7355-4623-8f75-3cb79bc7f2fc

## 確認したこと

- [x] shake_gesture パッケージが正しくインストールされること
- [x] ShakeDetection ウィジェットが正常に動作すること
- [x] iOS 依存関係が正しく更新されること
- [x] iOS Simulator で Shake が検出されてデバッグ画面が表示されること

## 動作確認手順

1. アプリを起動する
2. デバッグモードで shake 検出が正常に動作することを確認する

## 備考

- shake_gesture パッケージは shake パッケージよりも軽量で、パフォーマンスが向上します
- StatefulWidget から StatelessWidget への変更により、コードがより簡潔になりました