### PR TITLE
GH-529: 自動生成後にフォーマットを実行しなくてよくする

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -102,6 +102,33 @@ melos:
         dirExists: lib
         dependsOn: custom_lint
 
+    format:
+      description: |
+        すべてのパッケージに `dart format` を実行します。
+        自動生成されたコードは対象外になるように設定しています。
+      exec: >-
+        find lib -name "*.dart"
+        -not -path "*/gen/*"
+        -not -name "*.g.dart"
+        -not -name "*.freezed.dart"
+        -not -name "*.gen.dart"
+        -not -name "*.g.theme.dart" | xargs dart format
+      packageFilters:
+        dirExists: lib
+    format:check:
+      description: |
+        すべてのパッケージに `dart format --output=none --set-exit-if-changed` を実行します。
+        自動生成されたコードは対象外になるように設定しています。
+      exec: >-
+        find lib -name "*.dart"
+        -not -path "*/gen/*"
+        -not -name "*.g.dart"
+        -not -name "*.freezed.dart"
+        -not -name "*.gen.dart"
+        -not -name "*.g.theme.dart" | xargs dart format --output=none --set-exit-if-changed
+      packageFilters:
+        dirExists: lib
+
     gen:
       description: build_runner と l10n の生成コマンドを実行します。
       steps:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -141,21 +141,21 @@ melos:
         - gen:build:diff:main
     gen:build:
       description: build_runner を使用してコードを生成します。
-      run: dart run build_runner build -d && dart format .
+      run: dart run build_runner build -d
       exec:
         orderDependents: true
       packageFilters:
         dependsOn: build_runner
     gen:l10n:
       description: 多言語対応のためのローカライゼーションファイルを生成します。
-      run: flutter gen-l10n && dart format .
+      run: flutter gen-l10n
       exec:
         orderDependents: true
       packageFilters:
         dependsOn: flutter_localizations
     gen:build:diff:main:
       description: main ブランチと差分のあるパッケージのみ build_runner を使用してコードを生成します。
-      run: dart run build_runner build -d && dart format .
+      run: dart run build_runner build -d
       exec:
         orderDependents: true
       packageFilters:
@@ -163,7 +163,7 @@ melos:
         diff: origin/main...HEAD
     gen:l10n:diff:main:
       description: main ブランチと差分のあるパッケージのみ 多言語対応のためのローカライゼーションファイルを生成します。
-      run: flutter gen-l10n && dart format .
+      run: flutter gen-l10n
       exec:
         orderDependents: true
       packageFilters:
@@ -178,7 +178,7 @@ melos:
         - gen:l10n:diff:head
     gen:build:diff:head:
       description: 未コミットの差分パッケージのみ build_runner を使用してコードを生成します。
-      run: dart run build_runner build -d && dart format .
+      run: dart run build_runner build -d
       exec:
         orderDependents: true
       packageFilters:
@@ -186,7 +186,7 @@ melos:
         diff: ""
     gen:l10n:diff:head:
       description: 未コミットの差分パッケージのみ ローカライゼーションファイル を生成します。
-      run: flutter gen-l10n && dart format .
+      run: flutter gen-l10n
       exec:
         orderDependents: true
       packageFilters:


### PR DESCRIPTION
## 概要

close: #529

Dart 3.8更新によるフォーマット問題を解決するため、自動生成後にフォーマットを実行しないようにしました。
代わりに、専用の`format`コマンドと`format:check`コマンドを追加し、フォーマットとコード生成を独立して実行できるようにしました。

## レビュー観点

- melosコマンドの設定変更が適切か
- 新しく追加されたformatコマンドの設定が適切か
- 既存のgenコマンドからdart formatが適切に削除されているか
- 自動生成ファイルのフォーマット問題が解決されているか

## レビューレベル

- [x] Lv1: ぱっとみて違和感がないかチェックして Approve する

## レビュー優先度

- [ ] 数日以内で見てもらいたい 🐢

## 画像 / 動画

見た目に関する変更がないため省略します。

## 確認したこと

- [x] melosコマンドの設定が正しく更新されていること
- [x] 新しく追加されたformatコマンドが適切に設定されていること
- [x] 既存のgenコマンドからdart formatが削除されていること
- [x] 自動生成ファイルのフォーマット問題が解決されていること

## 動作確認手順

1. `melos format`を実行して、すべてのパッケージでフォーマットが実行されることを確認
2. `melos format:check`を実行して、フォーマットチェックが正常に動作することを確認
3. `melos gen:build`を実行して、build_runnerのみが実行されることを確認

## 備考

Dart 3.8更新により、自動生成パッケージでのフォーマット機能が問題を起こしていたため、一時的に自動生成後にフォーマットを実行していました。
PR #537でパッケージの更新が完了し、Dart 3.8でのフォーマット問題は再現できなくなったため、この変更により、フォーマットとコード生成を独立して実行できるようになり、CIパイプラインでの問題が解決されます。