### PR TITLE
refactor: apps/appのbuild.yamlを最適化

### DIFF
--- a/apps/app/build.yaml
+++ b/apps/app/build.yaml
@@ -9,11 +9,11 @@ targets:
       riverpod_generator:
         generate_for:
           include:
-            - lib/{providers,**/providers}/**.dart
             - lib/composition_root/**/*.dart
             - lib/router/router.dart
-            # ページファイル内で navigatorProvider を定義できるようにする
-            - lib/**/*_page.dart
+            # 状態管理用の Provider やページ内で navigatorProvider を定義できるようにする
+            - lib/presentation/providers/**.dart
+            - lib/presentation/ui/**_page.dart
       # https://github.com/dart-lang/source_gen#ignore_for_file
       source_gen:combining_builder:
         options:

--- a/apps/app/build.yaml
+++ b/apps/app/build.yaml
@@ -5,7 +5,6 @@ targets:
         # https://github.com/dart-lang/build/blob/master/docs/faq.md#how-do-i-avoid-running-builders-on-unnecessary-inputs
         generate_for:
           include:
-            - lib/{model,**/model}/**.dart
             - lib/configuration/**.dart
       riverpod_generator:
         generate_for:

--- a/apps/app/build.yaml
+++ b/apps/app/build.yaml
@@ -11,7 +11,7 @@ targets:
         generate_for:
           include:
             - lib/{providers,**/providers}/**.dart
-            - lib/{composition_root,**/composition_root}/**.dart
+            - lib/composition_root/**/*.dart
             - lib/router/router.dart
             # ページファイル内で navigatorProvider を定義できるようにする
             - lib/**/*_page.dart

--- a/apps/app/build.yaml
+++ b/apps/app/build.yaml
@@ -9,11 +9,13 @@ targets:
       riverpod_generator:
         generate_for:
           include:
+            # 依存注入用の Provider
             - lib/composition_root/**/*.dart
-            - lib/router/router.dart
-            # 状態管理用の Provider やページ内で navigatorProvider を定義できるようにする
+            # 状態管理用の Provider やページごとの navigatorProvider
             - lib/presentation/providers/**.dart
             - lib/presentation/ui/**_page.dart
+            # ルーティング用の Provider
+            - lib/router/router.dart
       # https://github.com/dart-lang/source_gen#ignore_for_file
       source_gen:combining_builder:
         options:

--- a/apps/app/build.yaml
+++ b/apps/app/build.yaml
@@ -7,15 +7,6 @@ targets:
           include:
             - lib/{model,**/model}/**.dart
             - lib/configuration/**.dart
-      # https://github.com/google/json_serializable.dart/tree/master/json_serializable#build-configuration
-      json_serializable:
-        generate_for:
-          include:
-            - lib/{model,**/model}/**.dart
-        options:
-          field_rename: snake
-          # json のデシリアライズ時に発生する Exception を CheckedFromJsonException にまとめる
-          checked: true
       riverpod_generator:
         generate_for:
           include:

--- a/apps/app/pubspec.yaml
+++ b/apps/app/pubspec.yaml
@@ -36,7 +36,6 @@ dependencies:
   internal_util_ui:
     path: ../../packages/util_ui
   intl: ^0.20.2
-  json_annotation: ^4.9.0
   package_info_plus: ^8.3.0
   pub_semver: ^2.2.0
   riverpod_annotation: ^2.6.1
@@ -53,7 +52,6 @@ dev_dependencies:
     sdk: flutter
   freezed: ^3.0.6
   go_router_builder: ^2.9.0
-  json_serializable: ^6.9.5
   riverpod_generator: ^2.6.5
   riverpod_lint: ^2.6.5
 


### PR DESCRIPTION
## 概要

- close: #579

apps/appのbuild.yamlに現在余計なものが含まれているため、より最適な構成に見直しました。

## レビュー観点

- build.yamlの設定が実際のファイル構造と一致しているか
- 不要な依存関係が適切に削除されているか
- コメントが適切に改善されているか

## レビューレベル

- [x] Lv1: ぱっとみて違和感がないかチェックして Approve する

## レビュー優先度

- [x] 数日以内で見てもらいたい 🐢

## 画像 / 動画

- 見た目に関する変更がないため省略します。

## 確認したこと

- [x] json_serializableが実際に使用されていないことを確認
- [x] 各パターンが実際のファイル構造と一致していることを確認
- [x] 不要な依存関係が適切に削除されていることを確認

## 動作確認手順

1. `cd apps/app && dart run build_runner build --delete-conflicting-outputs` を実行
2. ビルドが正常に完了することを確認

## 備考

### 実施した最適化

1. **不要なjson_serializable設定の削除**
   - build.yamlからjson_serializableの設定を削除
   - pubspec.yamlからjson_annotationとjson_serializableの依存関係を削除

2. **パターンの最適化**
   - `lib/{composition_root,**/composition_root}/**.dart` → `lib/composition_root/**/*.dart`
   - `lib/{providers,**/providers}/**.dart` → `lib/presentation/providers/**.dart`
   - `lib/**/*_page.dart` → `lib/presentation/ui/**_page.dart`
   - 存在しない`lib/{model,**/model}/**.dart`パターンを削除

3. **コメントの改善**
   - 各パターンの役割を明確化（依存注入用、状態管理用、ルーティング用）
   - 将来の開発者が設定の意図を理解しやすくする