### PR TITLE
build.gradleは存在しないので、rename-application-id.sh で指定しているパスをbuild.gradle.ktsに修正し、namespace の変換が行われない問題を修正した

### DIFF
--- a/tools/rename-application-id.sh
+++ b/tools/rename-application-id.sh
@@ -47,7 +47,7 @@ echo "[Step2] Replacing the namespace definition in build.gradle in app module w
 
 readonly APP_BUILD_GRADLE_PATH="$PROJECT_ROOT/apps/app/android/app/build.gradle.kts"
 
-sed -i '' "s/namespace \"$OLD_NAMESPACE\"/namespace \"$NEW_ANDROID_APPLICATION_ID\"/" "$APP_BUILD_GRADLE_PATH"
+sed -i '' "s/namespace = \"$OLD_NAMESPACE\"/namespace = \"$NEW_ANDROID_APPLICATION_ID\"/" "$APP_BUILD_GRADLE_PATH"
 
 # [Step3] Delete old MainActivity.kt
 echo "[Step3] Deleting old MainActivity.kt..."

--- a/tools/rename-application-id.sh
+++ b/tools/rename-application-id.sh
@@ -45,7 +45,7 @@ done
 # [Step2] Replace the namespace definition in build.gradle in the app module with the new application ID.
 echo "[Step2] Replacing the namespace definition in build.gradle in app module with new application ID..."
 
-readonly APP_BUILD_GRADLE_PATH="$PROJECT_ROOT/apps/app/android/app/build.gradle"
+readonly APP_BUILD_GRADLE_PATH="$PROJECT_ROOT/apps/app/android/app/build.gradle.kts"
 
 sed -i '' "s/namespace \"$OLD_NAMESPACE\"/namespace \"$NEW_ANDROID_APPLICATION_ID\"/" "$APP_BUILD_GRADLE_PATH"
 


### PR DESCRIPTION
## 概要

close #606 

- アプリケーションIDリネームスクリプト（`tools/rename-application-id.sh`）の修正
- AndroidのビルドファイルがGroovyからKotlin DSL（`.kts`）に移行したことに伴い、参照先のファイルパスを `build.gradle` から `build.gradle.kts` に更新しました
- namespace の変換処理が Gradle に対応した表記のままだったので、Kotlin 版に対応した記述方法にマッチするように修正

## レビュー観点

- ファイルパスの変更が正しいか
- スクリプトを実行してエラーが発生しないか、およびアプリ ID が更新されるか
- `build.gradle.kts` の `namespace` が更新されるか

## レビューレベル

- [x] Lv1: ぱっとみて違和感がないかチェックして Approve する
- [ ] Lv2: 仕様レベルまで理解して、仕様通りに動くかある程度検証して Approve する
- [ ] Lv3: 実際に環境で動作確認したうえで Approve する

## レビュー優先度

- [ ] すぐに見てもらいたい ( hotfix など ) 🚀
- [ ] 今日中に見てもらいたい 🚗
- [ ] 今日〜明日中で見てもらいたい 🚶
- [x] 数日以内で見てもらいたい 🐢

## 画像 / 動画

見た目に関する変更がないため省略します。

## 確認したこと

- [x] `apps/app/android/app/build.gradle.kts` が存在すること
- [x] スクリプト内のパス変更箇所が正しいこと
- [x] スクリプトを実行してエラーが発生しないこと、およびアプリ ID が更新されること
- [x] `build.gradle.kts` の `namespace` が更新されること
- [x] Android アプリが起動すること


## 動作確認手順

1. `tools/rename-application-id.sh` を実行して、正常に動作することを確認する

./tools/rename-application-id.sh "com.example.android" "com.example.ios"

## 備考

- なし